### PR TITLE
Include data by default in save func

### DIFF
--- a/src/rendering/fileio.jl
+++ b/src/rendering/fileio.jl
@@ -2,6 +2,6 @@ function fileio_load(f::FileIO.File{FileIO.format"vegalite"})
     return loadspec(f.filename)
 end
 
-function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=false)
+function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true)
     savespec(file.filename, data, include_data=include_data)
 end


### PR DESCRIPTION
That seems to lead to a better workflow, in particular in Jupyter Lab, where one can just open vegalite files to view them (if they have data in them, of course).