### PR TITLE
Enhancement request for JSON IO-related APIs

### DIFF
--- a/src/rendering/fileio.jl
+++ b/src/rendering/fileio.jl
@@ -6,12 +6,12 @@ function fileio_load(stream::FileIO.Stream{FileIO.format"vegalite"})
     return loadspec(stream.io)
 end
 
-function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true)
-    savespec(file.filename, data, include_data=include_data)
+function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true, kwargs...)
+    savespec(file.filename, data; include_data=include_data, kwargs...)
 end
 
-function fileio_save(stream::FileIO.Stream{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true)
-    savespec(stream.io, data, include_data=include_data)
+function fileio_save(stream::FileIO.Stream{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true, kwargs...)
+    savespec(stream.io, data; include_data=include_data, kwargs...)
 end
 
 function fileio_load(f::FileIO.File{FileIO.format"vega"})
@@ -22,10 +22,10 @@ function fileio_load(stream::FileIO.Stream{FileIO.format"vega"})
     return loadvgspec(stream.io)
 end
 
-function fileio_save(file::FileIO.File{FileIO.format"vega"}, data::VGSpec; include_data=true)
-    savespec(file.filename, data, include_data=include_data)
+function fileio_save(file::FileIO.File{FileIO.format"vega"}, data::VGSpec; include_data=true, kwargs...)
+    savespec(file.filename, data; include_data=include_data, kwargs...)
 end
 
-function fileio_save(stream::FileIO.Stream{FileIO.format"vega"}, data::VGSpec; include_data=true)
-    savespec(stream.io, data, include_data=include_data)
+function fileio_save(stream::FileIO.Stream{FileIO.format"vega"}, data::VGSpec; include_data=true, kwargs...)
+    savespec(stream.io, data; include_data=include_data, kwargs...)
 end

--- a/src/rendering/fileio.jl
+++ b/src/rendering/fileio.jl
@@ -2,14 +2,30 @@ function fileio_load(f::FileIO.File{FileIO.format"vegalite"})
     return loadspec(f.filename)
 end
 
+function fileio_load(stream::FileIO.Stream{FileIO.format"vegalite"})
+    return loadspec(stream.io)
+end
+
 function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true)
     savespec(file.filename, data, include_data=include_data)
+end
+
+function fileio_save(stream::FileIO.Stream{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=true)
+    savespec(stream.io, data, include_data=include_data)
 end
 
 function fileio_load(f::FileIO.File{FileIO.format"vega"})
     return loadvgspec(f.filename)
 end
 
+function fileio_load(stream::FileIO.Stream{FileIO.format"vega"})
+    return loadvgspec(stream.io)
+end
+
 function fileio_save(file::FileIO.File{FileIO.format"vega"}, data::VGSpec; include_data=true)
     savespec(file.filename, data, include_data=include_data)
+end
+
+function fileio_save(stream::FileIO.Stream{FileIO.format"vega"}, data::VGSpec; include_data=true)
+    savespec(stream.io, data, include_data=include_data)
 end

--- a/src/rendering/io.jl
+++ b/src/rendering/io.jl
@@ -53,19 +53,28 @@ loadvgspec(filename::AbstractString) = open(loadvgspec, filename)
 loadvgspec(io::IO) = VGSpec(JSON.parse(io))
 
 """
-    savespec(filename::AbstractString, v::VLSpec{:plot}; include_data=false)
-    savespec(io::IO, v::VLSpec{:plot}; include_data=false)
+    savespec(filename::AbstractString, v::VLSpec{:plot})
+    savespec(io::IO, v::VLSpec{:plot})
 
 Save the plot `v` as a vega-lite specification file with the name `filename`.
-An `IO` object can also be passed. The `include_data` argument controls
-whether the data should be included in the saved specification file.
+An `IO` object can also be passed.
+
+# Keyword Arguments
+- `include_data::Bool`: The `include_data` argument controls
+  whether the data should be included in the saved specification file.
+- `indent::Union{Nothing,Integer}`: Pretty-print JSON output with given
+  indentation if `indent` is an integer.
 """
-function savespec(io::IO, v::AbstractVegaSpec; include_data=false)
+function savespec(io::IO, v::AbstractVegaSpec; include_data=false, indent=nothing)
     output_dict = copy(v.params)
     if !include_data
         delete!(output_dict, "data")
     end
-    JSON.print(io, output_dict)
+    if indent === nothing
+        JSON.print(io, output_dict)
+    else
+        JSON.print(io, output_dict, indent)
+    end
 end
 
 savespec(filename::AbstractString, v::AbstractVegaSpec; kwargs...) =

--- a/src/rendering/io.jl
+++ b/src/rendering/io.jl
@@ -35,14 +35,13 @@ end
 
 """
     loadspec(filename::AbstractString)
+    loadspec(io::IO)
 
-Load a vega-lite specification from a file with name `filename`. Returns
-a `VLSpec` object.
+Load a vega-lite specification from a file with name `filename`. An `IO`
+object can also be passed. Returns a `VLSpec` object.
 """
-function loadspec(filename::AbstractString)
-    s = read(filename, String)
-    return VLSpec{:plot}(JSON.parse(s))
-end
+loadspec(filename::AbstractString) = open(loadspec, filename)
+loadspec(io::IO) = VLSpec{:plot}(JSON.parse(io))
 
 """
     loadvgspec(filename::AbstractString)
@@ -50,27 +49,29 @@ end
 Load a vega specification from a file with name `filename`. Returns
 a `VGSpec` object.
 """
-function loadvgspec(filename::AbstractString)
-    s = read(filename, String)
-    return VGSpec(JSON.parse(s))
-end
+loadvgspec(filename::AbstractString) = open(loadvgspec, filename)
+loadvgspec(io::IO) = VGSpec(JSON.parse(io))
 
 """
     savespec(filename::AbstractString, v::VLSpec{:plot}; include_data=false)
+    savespec(io::IO, v::VLSpec{:plot}; include_data=false)
 
 Save the plot `v` as a vega-lite specification file with the name `filename`.
-The `include_data` argument controls whether the data should be included
-in the saved specification file.
+An `IO` object can also be passed. The `include_data` argument controls
+whether the data should be included in the saved specification file.
 """
-function savespec(filename::AbstractString, v::AbstractVegaSpec; include_data=false)
+function savespec(io::IO, v::AbstractVegaSpec; include_data=false)
     output_dict = copy(v.params)
     if !include_data
         delete!(output_dict, "data")
     end
-    open(filename, "w") do f
-        JSON.print(f, output_dict)
-    end
+    JSON.print(io, output_dict)
 end
+
+savespec(filename::AbstractString, v::AbstractVegaSpec; kwargs...) =
+    open(filename, "w") do io
+        savespec(io, v; kwargs...)
+    end
 
 """
     svg(filename::AbstractString, v::VLSpec{:plot})

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,6 +1,22 @@
+"""
+    printrepr(io, v::AbstractVegaSpec)
+
+Print representation of a Vega spec `v` parsable by Julia.  It accepts
+the same keyword arguments as [`savespec`](@ref).
+"""
+function printrepr(io::IO, v::Union{VLSpec{:plot}, VGSpec}; kwargs...)
+    println(io, v isa VGSpec ? "vg" : "vl", "\"\"\"")
+    savespec(io, v; include_data=true, indent=4, kwargs...)
+    print(io, "\"\"\"")
+end
 
 function Base.show(io::IO, m::MIME"text/plain", v::AbstractVegaSpec)
-    print(io, summary(v))
+    if !get(io, :compact, true) && v isa Union{VLSpec{:plot}, VGSpec}
+        printrepr(io, v)
+    else
+        print(io, summary(v))
+    end
+    return
 end
 
 function convert_to_svg(v::AbstractVegaSpec, script_path::String)

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -26,6 +26,10 @@ vlp = getvlplot()
         seek(io, 0)
         @test load(Stream(fmt, io)).params == plt.params
     end
+
+    let code = repr("text/plain", plt, context=:compact=>false)
+        @test include_string(@__MODULE__, code).params == plt.params
+    end
 end
 
 Base.Filesystem.mktempdir() do folder

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -10,17 +10,19 @@ p = DataFrame(x = [1,2,3], y=[1,2,3]) |> @vlplot(:point, x="x:q", y="y:q")
 vgp = getvgplot()
 vlp = getvlplot()
 
-@testset "$fmt" for (fmt, plt) in [
+@testset "$fmt (indent=$(repr(indent)))" for (fmt, plt) in [
     (format"vegalite", vlp)
     # (format"vega", vgp)  # waiting for FileIO
-]
-    let json = sprint(io -> save(Stream(fmt, io), plt)),
+],
+    indent in [nothing, 4]
+
+    let json = sprint(io -> save(Stream(fmt, io), plt, indent=indent)),
         code = "vg\"\"\"$json\"\"\""
         @test include_string(@__MODULE__, code).params == plt.params
     end
 
     let io = IOBuffer()
-        save(Stream(fmt, io), plt)
+        save(Stream(fmt, io), plt, indent=indent)
         seek(io, 0)
         @test load(Stream(fmt, io)).params == plt.params
     end

--- a/test/testhelper_create_vg_plot.jl
+++ b/test/testhelper_create_vg_plot.jl
@@ -97,3 +97,20 @@ function getvgplot()
 }
 """
 end
+
+function getvlplot()
+    return vl"""
+{
+  "data": {
+    "values": [
+      {"a": "A","b": 28}, {"a": "B","b": 55}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "a", "type": "ordinal"},
+    "y": {"field": "b", "type": "quantitative"}
+  }
+}
+"""
+end


### PR DESCRIPTION
This PR extends save/load APIs.

1. The first commit adds `io`-accepting variants for the save/load functions (e.g., `save(Stream(format"vegalite", io), spec)`)

2. The second commit adds `indent` keyword argument so that `save` functions can pretty-print JSON.

3. The third commit lets `show(IOContext(stdout, :compact=>false), "text/plain", spec)` use the pretty-printed JSON and `vl"..."` macro to produce evaluatable Julia code.  This is useful, e.g., for generating executable Julia code from `DataVoyager` output.
