### PR TITLE
refactor: start spec_utils to encourage more use of abstract spec type

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -66,8 +66,7 @@ actionlinks(b::Bool) = (global ACTIONSLINKS ; ACTIONSLINKS = b)
 
 
 ########################  includes  #####################################
-
-abstract type AbstractVegaSpec end
+include("spec_utils.jl")
 include("vgspec.jl")
 include("vlspec.jl")
 

--- a/src/spec_utils.jl
+++ b/src/spec_utils.jl
@@ -1,0 +1,3 @@
+abstract type AbstractVegaSpec end
+
+Base.copy(spec::T) where {T <: AbstractVegaSpec} = T(copy(spec.params))

--- a/src/vgspec.jl
+++ b/src/vgspec.jl
@@ -95,4 +95,3 @@ Create a copy of `spec` without data.  See also [`deletedata!`](@ref).
 deletedata(spec::VGSpec) = deletedata!(copy(spec))
 
 Base.:(==)(x::VGSpec, y::VGSpec) = x.params == y.params
-Base.copy(spec::VGSpec) = VGSpec(copy(spec.params))

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -73,7 +73,6 @@ function (p::VLSpec{:plot})(path::AbstractPath)
 end
 
 Base.:(==)(x::VLSpec, y::VLSpec) = vltype(x) == vltype(y) && x.params == y.params
-Base.copy(spec::T) where {T <: VLSpec} = T(copy(spec.params))
 
 """
     deletedata!(spec::VLSpec)


### PR DESCRIPTION
A minor refactoring and consolidation of methods to encourage more use of the abstract spec type for things that are generic to both vega and vega-lite.