### PR TITLE
Disallow vectors for .params

### DIFF
--- a/src/vgspec.jl
+++ b/src/vgspec.jl
@@ -1,5 +1,5 @@
 struct VGSpec <: AbstractVegaSpec
-    params::Union{Dict, Vector}
+    params::Dict
 end
 
 # data is an array in vega

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 struct VLSpec{T} <: AbstractVegaSpec
-    params::Union{Dict, Vector}
+    params::Dict
 end
 vltype(::VLSpec{T}) where T = T
 


### PR DESCRIPTION
IIUC (all?) internal functions seem to expect `.params` to be a dictionary. Would it make sense to encode it the spec type if so?