### PR TITLE
Support Tables.jl-based tables?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -3,6 +3,7 @@ module VegaLite
 using JSON, NodeJS # 6s
 import IteratorInterfaceExtensions # 1s
 import TableTraits # 0
+import Tables
 using FileIO # 17s !!!
 using DataValues  # 1s
 import MacroTools

--- a/src/spec_utils.jl
+++ b/src/spec_utils.jl
@@ -44,3 +44,10 @@ end
 
 _maybeparams(value) = value
 _maybeparams(value::ObjectLike) = getparams(value)
+
+_getiterator(data) =
+    if TableTraits.isiterabletable(data)
+        IteratorInterfaceExtensions.getiterator(data)
+    else
+        Tables.rowtable(data)
+    end

--- a/src/vgspec.jl
+++ b/src/vgspec.jl
@@ -17,13 +17,12 @@ function vg_set_spec_data!(specdict, datait, name)
 end
 
 function (p::VGSpec)(data, name::String)
-    TableTraits.isiterabletable(data) || throw(ArgumentError("'data' is not a table."))
+    it = _getiterator(data)
 
     new_dict = copy(getparams(p))
 
     @assert haskey(new_dict, "data") "Must have data array in specification"
 
-    it = IteratorInterfaceExtensions.getiterator(data)
     vg_set_spec_data!(new_dict, it, name)
     detect_encoding_type!(new_dict, it)
 

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -42,11 +42,10 @@ function detect_encoding_type!(specdict, datait)
 end
 
 function (p::VLSpec{:plot})(data)
-    TableTraits.isiterabletable(data) || throw(ArgumentError("'data' is not a table."))
+    it = _getiterator(data)
 
     new_dict = copy(getparams(p))
 
-    it = IteratorInterfaceExtensions.getiterator(data)
     vl_set_spec_data!(new_dict, it)
     detect_encoding_type!(new_dict, it)
 


### PR DESCRIPTION
It would be nice if VegaLite supports table-like objects as much as possible, including the ones based on Tables.jl API.  I think this can be easily done by using

```julia
_getiterator(data) =
    if TableTraits.isiterabletable(data)
        IteratorInterfaceExtensions.getiterator(data)
    else
        Tables.rowtable(data)
    end
```

internally instead of `IteratorInterfaceExtensions.getiterator`.

A nice thing is that you can now do

```julia
(x=randn(100), y=randn(100)) |> @vlplot(:point, x=:x, y=:y)
```

which I find quite handy.

What do you think? I can add some tests if you are OK with this direction.