### PR TITLE
Include only required fields in data

### DIFF
--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -202,7 +202,7 @@ end
 
 function Base.display(d::REPL.REPLDisplay, plt::VLSpec{:plot})
   # checkplot(plt)
-  tmppath = writehtml_full(JSON.json(getparams(plt)))
+  tmppath = writehtml_full(render_json(plt))
   launch_browser(tmppath) # Open the browser
 end
 
@@ -210,3 +210,7 @@ function Base.display(d::REPL.REPLDisplay, plt::VGSpec)
   tmppath = write_vg_html_full(JSON.json(getparams(plt)))
   launch_browser(tmppath) # Open the browser
 end
+
+render_json(x) = sprint(render_json, x)
+render_json(io::IO, plt::VLSpec) =
+    JSON.print(io, getparams(with_stripped_data(plt)))

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -21,7 +21,7 @@ end
 
 function convert_vl_to_vg(v::VLSpec{:plot})
     vl2vg_script_path = joinpath(@__DIR__, "vl2vg.js")
-    data = JSON.json(getparams(v))
+    data = render_json(v)
     p = open(`$(nodejs_cmd()) $vl2vg_script_path`, "r+")
     writer = @async begin
         write(p, data)
@@ -39,7 +39,7 @@ end
 function convert_vl_to_x(v::VLSpec{:plot}, second_script)
     vl2vg_script_path = joinpath(@__DIR__, "vl2vg.js")
     full_second_script_path = joinpath(@__DIR__, "..", "..", "deps", "node_modules", "vega-cli", "bin", second_script)
-    data = JSON.json(getparams(v))
+    data = render_json(v)
     p = open(pipeline(`$(nodejs_cmd()) $vl2vg_script_path`, `$(nodejs_cmd()) $full_second_script_path`), "r+")
     writer = @async begin
         write(p, data)
@@ -75,7 +75,7 @@ Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.vegalite.v3+json")}) =
 Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.vega.v5+json")}) = true
 
 function Base.show(io::IO, m::MIME"application/vnd.vegalite.v3+json", v::VLSpec{:plot})
-     print(io, JSON.json(getparams(v)))
+    render_json(io, v)
 end
 
 function Base.show(io::IO, m::MIME"application/vnd.vega.v5+json", v::VGSpec)


### PR DESCRIPTION
This PR makes the following snippet work

```julia
using ElectronDisplay
using VegaLite
[
    (
        x = randn(),
        y = randn(),
        dummy = randn(10^5),
    )
    for _ in 1:100
] |>
@vlplot(:point, x=:x, y=:y)
```

Before this PR, it hangs as described in https://github.com/davidanthoff/Electron.jl/issues/37.  While this is not the direct solution for https://github.com/davidanthoff/Electron.jl/issues/37, I think this still is a nice feature to have as this can drastically reduce generated JSON sometimes.  The only downside may be that you can't open the plot in Vega Editor and use different fields on the fly.  I think we can add global and per-plot configuration for this if that's needed.
