### PR TITLE
Use DisplayAs for a large map

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+DisplayAs = "0b91fe84-8a4c-11e9-3e1d-67c38462b6d6"
 
 [compat]
 Documenter = "~0.24"

--- a/docs/src/examples/examples_maps.md
+++ b/docs/src/examples/examples_maps.md
@@ -34,7 +34,7 @@ unemployment = dataset("unemployment")
 ## One dot per zipcode in the U.S.
 
 ```@example
-using VegaLite, VegaDatasets
+using VegaLite, VegaDatasets, DisplayAs
 
 dataset("zipcodes") |> @vlplot(
     :circle,
@@ -45,8 +45,11 @@ dataset("zipcodes") |> @vlplot(
     latitude="latitude:q",
     size={value=1},
     color="digit:n"
-)
+) |>
+DisplayAs.PNG
 ```
+
+Note how we use [DisplayAs.jl](https://github.com/tkf/DisplayAs.jl) here to output the result as a PNG, which behaves better in this example with a large number of dots.
 
 ## One dot per airport in the US overlayed on geoshape
 


### PR DESCRIPTION
@oheil Without this the map gets displayed as a SVG in the documentation, and with the many dots that is super slow.

Ideally of course we would find a way to actually use the vega-lite viewer in the documentation, so that we also have interactivity, but that is probably a bigger project :)