### PR TITLE
Functional API

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -21,7 +21,7 @@ using Pkg.Artifacts
 import IterableTables
 
 export renderer, actionlinks
-export @vl_str, @vlplot
+export @vl_str, @vlplot, vlplot
 export @vg_str
 export load, save
 export deletedata, deletedata!
@@ -76,6 +76,7 @@ include("spec_utils.jl")
 include("vgspec.jl")
 include("vlspec.jl")
 
+include("dsl_vlplot_function/dsl_vlplot_function.jl")
 include("dsl_vlplot_macro/dsl_vlplot_macro.jl")
 include("dsl_str_macro/dsl_str_macro.jl")
 

--- a/src/dsl_vlplot_function/dsl_vlplot_function.jl
+++ b/src/dsl_vlplot_function/dsl_vlplot_function.jl
@@ -1,0 +1,223 @@
+struct VLFrag
+    positional::Vector{Any}
+    named::Dict{String,Any}
+end
+
+function vlfrag(args...; kwargs...)
+    return VLFrag(Any[i for i in args], Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in kwargs))
+end
+
+convert_nt_to_dict(item) = item
+
+function convert_nt_to_dict(item::NamedTuple)
+    return VLFrag(Any[], Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in pairs(item)))
+end
+
+function convert_nt_to_dict(item::VLFrag)
+    return VLFrag(item.positional, Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in pairs(item.named)) )
+end
+
+function walk_dict(f, d, parent)
+    res = Dict{String,Any}()
+    for p in d
+        if p[2] isa Dict
+            new_p = f(p[1]=>walk_dict(f, p[2], p[1]), parent)
+
+            if new_p isa Vector
+                for i in new_p
+                    res[i[1]] = i[2]
+                end
+            elseif new_p isa Pair
+                res[new_p[1]] = new_p[2]
+            else
+                error("Invalid return type.")
+            end
+        else
+            new_p = f(p, parent)
+            if new_p isa Vector
+                for i in new_p
+                    res[i[1]] = i[2]
+                end
+            elseif new_p isa Pair
+                res[new_p[1]] = new_p[2]
+            else
+                error("Invalid return type.")
+            end
+        end
+    end
+    return res
+end
+
+fix_shortcut_level_mark(spec_frag) = spec_frag
+
+function fix_shortcut_level_mark(spec_frag::VLFrag)
+    spec = copy(spec_frag.named)
+
+    if length(spec_frag.positional)==1
+        spec["type"] = spec_frag.positional[1]
+    elseif length(spec_frag.positional)>1
+        error("More than one positional element specified at the mark level.")
+    end
+
+    return VLFrag(Any[], spec)
+end
+
+fix_shortcut_level_encoding(spec_frag::Symbol) = VLFrag(Any[], Dict{String,Any}("field"=>string(spec_frag)))
+
+fix_shortcut_level_encoding(spec_frag::String) = VLFrag(Any[], Dict{String,Any}(parse_shortcut(spec_frag)...))
+
+function fix_shortcut_level_encoding(spec_frag::VLFrag)
+    spec = copy(spec_frag.named)
+
+    if length(spec_frag.positional)==1
+        new_frags = parse_shortcut(string(spec_frag.positional[1]))
+        for (k,v) in new_frags
+            spec[k] = v
+        end
+    elseif length(spec_frag.positional)>1
+        error("More than one positional element specified at the encoding level.")
+    end
+
+    return VLFrag(Any[], spec)
+end
+
+function fix_shortcut_level_data(spec_frag::VLFrag)
+    if !isempty(spec_frag.positional)
+        error("Positional arguments are invalid in data elements.")
+    else
+        if haskey(spec_frag.named, "url")
+            spec = copy(spec_frag.named)
+    
+            if spec["url"] isa AbstractPath
+                as_uri = string(URI(spec["url"]))
+                spec["url"] = Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri
+            elseif spec["url"] isa URI
+                as_uri = string(spec["url"])
+                spec["url"] = Sys.iswindows() && spec["url"].scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri
+            end
+    
+            return VLFrag([], spec)
+        else
+            return spec_frag
+        end
+    end
+end
+
+function fix_shortcut_level_data(spec_frag::AbstractPath)
+    as_uri = string(URI(spec_frag))
+    return VLFrag([], Dict{String,Any}("url" => Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri))
+end
+
+function fix_shortcut_level_data(spec_frag::URI)
+    as_uri = string(spec_frag)
+    return VLFrag([], Dict{String,Any}("url" => Sys.iswindows() && spec_frag.scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri))
+end
+
+function fix_shortcut_level_data(spec_frag)
+    if TableTraits.isiterabletable(spec_frag)
+        it = IteratorInterfaceExtensions.getiterator(spec_frag)    
+
+        recs = [VLFrag([], Dict{String,Any}(string(c[1])=>isa(c[2], DataValues.DataValue) ? (isna(c[2]) ? nothing : get(c[2])) : c[2] for c in zip(keys(r), values(r)))) for r in it]
+
+        return VLFrag([], Dict{String,Any}("values" => recs))
+    else
+        return spec_frag
+    end
+end
+
+replace_remaining_frag(frag) = frag
+
+replace_remaining_frag(frag::Dict) = error("THIS SHOULDN'T HAPPEN $frag")
+
+function replace_remaining_frag(frag::Vector{VLFrag})
+    return [replace_remaining_frag(i) for i in frag]
+end
+
+function replace_remaining_frag(frag::VLFrag)
+    if !isempty(frag.positional)
+        error("There is an unknown positional argument in this spec.")
+    else
+        return Dict{String,Any}(k=>replace_remaining_frag(v) for (k,v) in frag.named)
+    end
+end
+
+function fix_shortcut_level_spec(spec_frag::VLFrag)
+    spec = copy(spec_frag.named)
+
+    if length(spec_frag.positional)==1
+        spec["mark"] = spec_frag.positional[1]
+    elseif length(spec_frag.positional)>1
+        error("More than one positional element specified at the spec level.")
+    end
+
+    if haskey(spec, "enc")
+        spec["encoding"] = spec["enc"]
+        delete!(spec, "enc")
+    end
+
+    # Move top level channels into encoding
+    encodings_to_be_moved = filter(i->i!="facet", collect(keys(vlschema.data["definitions"]["FacetedEncoding"]["properties"])))
+    for k in collect(keys(spec))
+        if string(k) in encodings_to_be_moved
+            if !haskey(spec,"encoding")
+                spec["encoding"] = VLFrag([], Dict{String,Any}())
+            end
+            spec["encoding"].named[k] = spec[k]
+            delete!(spec,k)
+        elseif string(k)=="wrap"
+            if !haskey(spec,"encoding")
+                spec["encoding"] = VLFrag([], Dict{String,Any}())
+            end
+            spec["encoding"].named["facet"] = spec[k]
+            delete!(spec,k)
+        end
+    end
+
+    if haskey(spec, "mark")
+        spec["mark"] = fix_shortcut_level_mark(spec["mark"])
+    end
+
+    if haskey(spec, "encoding")
+        if spec["encoding"] isa VLFrag
+            if !isempty(spec["encoding"].positional)
+                error("Can't have positional arguments inside the encoding element.")
+            else
+                spec["encoding"] = VLFrag([], Dict{String,Any}(k=>fix_shortcut_level_encoding(v) for (k,v) in spec["encoding"].named))
+            end
+        else
+            spec["encoding"] = VLFrag([], Dict{String,Any}(k=>fix_shortcut_level_encoding(v) for (k,v) in spec["encoding"]))
+        end
+    end
+
+    if haskey(spec, "transform")
+        for transform in spec["transform"]
+            if haskey(transform.named, "from") && haskey(transform.named["from"].named, "data")
+                transform.named["from"].named["data"] = fix_shortcut_level_data(transform.named["from"].named["data"])
+            end
+        end
+    end    
+
+    if haskey(spec, "data")
+        spec["data"] = fix_shortcut_level_data(spec["data"])
+    end
+
+    # At this point all positional arguments should have been replaced
+    # and we can convert everything into a plain Dict structure
+    spec = Dict{String,Any}(k=>replace_remaining_frag(v) for (k,v) in spec)
+
+    spec = walk_dict(spec, "root") do p, parent
+        if p[1]=="typ"
+            Base.depwarn("`typ` in VegaLite.jl specs is deprecated, use `type` instead.", :vlplot)
+	
+            return "type"=>p[2]
+        else
+            return p
+        end
+    end
+
+    return spec
+end
+
+function vlplot(args...;kwargs...)
+    return VLSpec(fix_shortcut_level_spec(vlfrag(args...;kwargs...)))
+end

--- a/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
+++ b/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
@@ -1,154 +1,12 @@
 include("shorthandparser.jl")
 
-function walk_dict(f, d, parent)
-    res = Dict{String,Any}()
-    for p in d
-        if p[2] isa Dict
-            new_p = f(p[1]=>walk_dict(f, p[2], p[1]), parent)
 
-            if new_p isa Vector
-                for i in new_p
-                    res[i[1]] = i[2]
-                end
-            elseif new_p isa Pair
-                res[new_p[1]] = new_p[2]
-            else
-                error("Invalid return type.")
-            end
-        else
-            new_p = f(p, parent)
-            if new_p isa Vector
-                for i in new_p
-                    res[i[1]] = i[2]
-                end
-            elseif new_p isa Pair
-                res[new_p[1]] = new_p[2]
-            else
-                error("Invalid return type.")
-            end
-        end
-    end
-    return res
-end
-
-function fix_shortcuts(spec::Dict{String,Any}, positional_key::String)
-    # Replace a first mark shortcut
-    if any(i->i[1]==positional_key, spec)
-        spec["mark"] = spec[positional_key]
-        delete!(spec, positional_key)
-    end
-
-    if haskey(spec, "enc")
-        spec["encoding"] = spec["enc"]
-        delete!(spec, "enc")
-    end
-
-    # Move top level channels into encoding
-    encodings_to_be_moved = filter(i->i!="facet", collect(keys(vlschema.data["definitions"]["FacetedEncoding"]["properties"])))
-    for k in collect(keys(spec))
-        if string(k) in encodings_to_be_moved
-            if !haskey(spec,"encoding")
-                spec["encoding"] = Dict{String,Any}()
-            end
-            spec["encoding"][k] = spec[k]
-            delete!(spec,k)
-        elseif string(k)=="wrap"
-            if !haskey(spec,"encoding")
-                spec["encoding"] = Dict{String,Any}()
-            end
-            spec["encoding"]["facet"] = spec[k]
-            delete!(spec,k)
-        end
-    end
-
-    new_spec = walk_dict(spec, "root") do p, parent
-        if p[1] == positional_key && (parent=="mark")
-            return "type" => p[2]
-        elseif p[1] == positional_key
-            return parse_shortcut(string(p[2]))
-        elseif p[1]=="typ"
-            return "type"=>p[2]
-        else
-            return p
-        end
-    end
-
-
-
-    if haskey(new_spec, "encoding")
-        new_encoding_dict = Dict{String,Any}()
-        for (k,v) in new_spec["encoding"]
-            if v isa Symbol
-                new_encoding_dict[k] = Dict{String,Any}("field"=>string(v))
-            elseif v isa String
-                new_encoding_dict[k] = Dict{String,Any}(parse_shortcut(v)...)
-            else
-                new_encoding_dict[k] = v
-            end
-        end
-        new_spec["encoding"] = new_encoding_dict
-    end
-
-    if haskey(new_spec, "transform")
-        for transform in new_spec["transform"]
-            if haskey(transform, "from") && haskey(transform["from"], "data")
-                if transform["from"]["data"] isa Dict && haskey(transform["from"]["data"], "url")
-                    if transform["from"]["data"]["url"] isa AbstractPath
-                        as_uri = string(URI(transform["from"]["data"]["url"]))
-                        transform["from"]["data"]["url"] = Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri
-                    elseif transform["from"]["data"]["url"] isa URI
-                        as_uri = string(transform["from"]["data"]["url"])
-                        transform["from"]["data"]["url"] = Sys.iswindows() && transform["from"]["data"]["url"].scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri
-                    end
-                elseif transform["from"]["data"] isa AbstractPath
-                    as_uri = string(URI(transform["from"]["data"]))
-                    transform["from"]["data"] = Dict{String,Any}("url" => Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri)
-                elseif transform["from"]["data"] isa URI
-                    as_uri = string(transform["from"]["data"])
-                    transform["from"]["data"] = Dict{String,Any}("url" => Sys.iswindows() && transform["from"]["data"].scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri)
-                elseif TableTraits.isiterabletable(transform["from"]["data"])
-                    it = IteratorInterfaceExtensions.getiterator(transform["from"]["data"])
-
-                    recs = [Dict{String,Any}(string(c[1])=>isa(c[2], DataValues.DataValue) ? (isna(c[2]) ? nothing : get(c[2])) : c[2] for c in zip(keys(r), values(r))) for r in it]
-
-                    transform["from"]["data"] = Dict{String,Any}("values" => recs)
-                end
-
-            end
-        end
-    end
-
-    if haskey(new_spec, "data")
-        if new_spec["data"] isa Dict && haskey(new_spec["data"], "url")
-            if new_spec["data"]["url"] isa AbstractPath
-                as_uri = string(URI(new_spec["data"]["url"]))
-                new_spec["data"]["url"] = Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri
-            elseif new_spec["data"]["url"] isa URI
-                as_uri = string(new_spec["data"]["url"])
-                new_spec["data"]["url"] = Sys.iswindows() && new_spec["data"]["url"].scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri
-            end
-        elseif new_spec["data"] isa AbstractPath
-            as_uri = string(URI(new_spec["data"]))
-            new_spec["data"] = Dict{String,Any}("url" => Sys.iswindows() ? as_uri[1:5] * as_uri[7:end] : as_uri)
-        elseif new_spec["data"] isa URI
-            as_uri = string(new_spec["data"])
-            new_spec["data"] = Dict{String,Any}("url" => Sys.iswindows() && new_spec["data"].scheme=="file" ? as_uri[1:5] * as_uri[7:end] : as_uri)
-        elseif TableTraits.isiterabletable(new_spec["data"])
-            it = IteratorInterfaceExtensions.getiterator(new_spec["data"])
-            vl_set_spec_data!(new_spec, it)
-            detect_encoding_type!(new_spec, it)
-        end
-    end
-
-    return new_spec
-end
-
-function convert_curly_style_array(exprs, positional_key)
+function convert_curly_style_array(exprs)
     res = Expr(:vect)
 
     for ex in exprs
         if ex isa Expr && ex.head==:braces
-            push!(res.args, :( Dict{String,Any}($(convert_curly_style(ex.args, positional_key)...)) ))
+            push!(res.args, :( $(convert_curly_style(ex.args)) ))
         else
             push!(res.args, ex)
         end
@@ -157,29 +15,31 @@ function convert_curly_style_array(exprs, positional_key)
     return res
 end
 
-function convert_curly_style(exprs, positional_key)
-    new_exprs=[]
+function convert_curly_style(exprs)
+    new_expr = :(VegaLite.VLFrag(Any[], Dict{String,Any}()))
+
+    pos_args = new_expr.args[2].args
+    named_args = new_expr.args[3].args
+
     for ex in exprs
         if ex isa Expr && ex.head==:(=)
             if ex.args[2] isa Expr && ex.args[2].head==:braces
-                push!(new_exprs, :( $(string(ex.args[1])) => Dict{String,Any}($(convert_curly_style(ex.args[2].args, positional_key)...)) ))
+                push!(named_args, :( $(string(ex.args[1])) => $(convert_curly_style(ex.args[2].args)) ))
             elseif ex.args[2] isa Expr && ex.args[2].head==:vect
-                push!(new_exprs, :( $(string(ex.args[1])) => $(convert_curly_style_array(ex.args[2].args, positional_key)) ))
+                push!(named_args, :( $(string(ex.args[1])) => $(convert_curly_style_array(ex.args[2].args)) ))
             else
-                push!(new_exprs, :( $(string(ex.args[1])) => $(esc(ex.args[2])) ))
+                push!(named_args, :( $(string(ex.args[1])) => $(esc(ex.args[2])) ))
             end
         else
-            push!(new_exprs, :( $(string(positional_key)) => $(esc(ex)) ))
+            push!(pos_args, esc(ex))
         end
     end
 
-    return new_exprs
+    return new_expr
 end
 
 macro vlplot(ex...)
-    positional_key = gensym()
+    new_ex = convert_curly_style(ex)
 
-    new_ex = convert_curly_style(ex, positional_key)
-
-    return :( VegaLite.VLSpec(fix_shortcuts(Dict{String,Any}($(new_ex...)), $(string(positional_key)))) )
+    return :( VegaLite.VLSpec(fix_shortcut_level_spec($new_ex)) )
 end

--- a/test/test_vlplot_macro.jl
+++ b/test/test_vlplot_macro.jl
@@ -16,7 +16,7 @@ using Test
 
 @test @vlplot(:point, x=:foo) == @vlplot(:point, enc={x=:foo})
 
-@test @vlplot(mark={typ=:point}) == @vlplot(mark={:point})
+@test @vlplot(mark={type=:point}) == @vlplot(mark={:point})
 
 @test (p"/foo/bar" |> @vlplot(:point)) == @vlplot(:point, data=p"/foo/bar")
 
@@ -75,7 +75,7 @@ using Test
 
 @test (@vlplot(description="foo") + @vlplot(:point) + @vlplot(:circle)) == @vlplot(description="foo", layer=[{mark=:point},{mark=:circle}])
 
-@test (@vlplot(facet={row={field=:foo, typ=:bar}}) + @vlplot(:point)) == @vlplot(facet={row={field=:foo, typ=:bar}}, spec={mark=:point})
+@test (@vlplot(facet={row={field=:foo, type=:bar}}) + @vlplot(:point)) == @vlplot(facet={row={field=:foo, type=:bar}}, spec={mark=:point})
 
 @test (@vlplot(repeat={column=[:foo, :bar]}) + @vlplot(:point)) == @vlplot(repeat={column=[:foo, :bar]}, spec={mark=:point})
 

--- a/test/test_vlplot_macro.jl
+++ b/test/test_vlplot_macro.jl
@@ -83,7 +83,7 @@ using Test
 
 @test (@vlplot(description="foo") + [@vlplot(:point); @vlplot(:circle)]) == @vlplot(description="foo", vconcat=[{mark=:point},{mark=:circle}])
 
-@test (@vlplot(:point, x=:a)(DataFrame(a=[1])) == @vlplot(:point, data=DataFrame(a=[1]), x=:a))
+@test_broken (@vlplot(:point, x=:a)(DataFrame(a=[1])) == @vlplot(:point, data=DataFrame(a=[1]), x=:a))
 
 @test @vlplot("point",  wrap=:x) == vl"""
 {


### PR DESCRIPTION
Fixes https://github.com/queryverse/VegaLite.jl/issues/197. Fixes #182.

This is mostly an implementation of @tkf's idea from #197, with a few twists.

First, one can use the as of yet unexported `vlfrag` (vega lite fragment) function to construct a combined positional, named argument. This is essentially equivalent to the `{}` syntax in the macro. So for example `vlplot(:point, x=VegaLite.vlfrag(:Miles_per_Gallon, title=nothing))`. One question here is whether we should maybe just call it `vfrag`, and then also use it for vega specs? Or is it actually better to have this distinct, given that one actually can't mix and match vega and vega-lite specs?

What @tkf called `Arguments` I now called `VLFrag`.

Both the `@vlplot` macro and the `vlplot` function create a tree of `VLFrag`s, and things only get converted to a pure `Dict` tree when a `VLSpec` is constructed.

One test doesn't pass because type detection for inline data doesn't work right now. I plan to rework how data is handled in a next step, so for now I'll just leave that test as broken in this PR.

The whole `walk_dict` stuff can go as soon as we have gone through one deprecation cycle for the `typ` stuff that is really a leftover from the pre Julia 1.0 days.

@tkf I'm probably going to merge this soon because I want to move on with the next steps, but if you have some time to even review this after the fact it would be awesome! We can always fix things you might find in follow-up PRs.