### PR TITLE
Finish vlfrag API

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -21,7 +21,7 @@ using Pkg.Artifacts
 import IterableTables
 
 export renderer, actionlinks
-export @vl_str, @vlplot, vlplot
+export @vl_str, @vlplot, vlplot, @vlfrag, vlfrag
 export @vg_str
 export load, save
 export deletedata, deletedata!

--- a/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
+++ b/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
@@ -43,3 +43,9 @@ macro vlplot(ex...)
 
     return :( VegaLite.VLSpec(fix_shortcut_level_spec($new_ex)) )
 end
+
+macro vlfrag(ex...)
+    new_ex = convert_curly_style(ex)
+
+    return new_ex
+end


### PR DESCRIPTION
This finishes the composability work started in #227. In particular, there is now a `@vlfrag` macro that supports creating fragments using the `{}` syntax, and both `@vlfrag` and `vlfrag` are now exported.

@haberdashPI, the example from https://github.com/queryverse/VegaLite.jl/issues/182 should now just work with e.g.
```julia
foo(x) = @vlfrag(string(x,":n"), scale={rangeStep=12}, axis={title=""})
```

Fixes #228.