### PR TITLE
Add more vega APIs

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -19,7 +19,7 @@ import TableTraitsUtils
 
 export renderer, actionlinks
 export @vl_str, @vlplot, vlplot, @vlfrag, vlfrag
-export @vg_str
+export @vg_str, @vgplot, vgplot, @vgfrag, vgfrag
 export load, save
 export deletedata, deletedata!
 

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -78,6 +78,7 @@ include("dsl_vlplot_function/dsl_vlplot_function.jl")
 include("dsl_vlplot_macro/dsl_vlplot_macro.jl")
 include("dsl_str_macro/dsl_str_macro.jl")
 
+include("rendering/to_julia.jl")
 include("rendering/render.jl")
 include("rendering/io.jl")
 include("rendering/show.jl")

--- a/src/dsl_vlplot_function/dsl_vlplot_function.jl
+++ b/src/dsl_vlplot_function/dsl_vlplot_function.jl
@@ -78,7 +78,7 @@ fix_shortcut_level_encoding(name, spec_frag::Symbol, unnamed_inline_data) = VLFr
 fix_shortcut_level_encoding(name, spec_frag::String, unnamed_inline_data) = VLFrag(Any[], Dict{String,Any}(parse_shortcut(spec_frag)...))
 
 function fix_shortcut_level_encoding(name, spec_frag::AbstractVector, unnamed_inline_data)
-    if name!="tooltip"
+    if !(name in ("tooltip", "detail", "order"))
         push!(unnamed_inline_data, Symbol(name)=>spec_frag)
         return VLFrag(Any[], Dict{String,Any}("field"=>string(name), "title"=>nothing))
     else
@@ -95,7 +95,7 @@ function fix_shortcut_level_encoding(name, spec_frag::VLFrag, unnamed_inline_dat
             for (k,v) in new_frags
                 spec[k] = v
             end
-        elseif spec_frag.positional[1] isa AbstractVector && string(name)!="tooltip"
+        elseif spec_frag.positional[1] isa AbstractVector && !(string(name) in ("tooltip", "detail", "order"))
             if haskey(spec, "field")
                 error("The $name encoding channel cannot have inline data and a `field` element.")
             end

--- a/src/dsl_vlplot_function/dsl_vlplot_function.jl
+++ b/src/dsl_vlplot_function/dsl_vlplot_function.jl
@@ -1,20 +1,31 @@
-struct VLFrag
+abstract type AbstractVegaFragment end
+
+struct VLFrag <: AbstractVegaFragment
+    positional::Vector{Any}
+    named::Dict{String,Any}
+end
+
+struct VGFrag <: AbstractVegaFragment
     positional::Vector{Any}
     named::Dict{String,Any}
 end
 
 function vlfrag(args...; kwargs...)
-    return VLFrag(Any[args...], Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in kwargs))
+    return VLFrag(Any[args...], Dict{String,Any}(string(k)=>convert_nt_to_dict(v, VLFrag) for (k,v) in kwargs))
 end
 
-convert_nt_to_dict(item) = item
-
-function convert_nt_to_dict(item::NamedTuple)
-    return VLFrag(Any[], Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in pairs(item)))
+function vgfrag(args...; kwargs...)
+    return VGFrag(Any[args...], Dict{String,Any}(string(k)=>convert_nt_to_dict(v, VGFrag) for (k,v) in kwargs))
 end
 
-function convert_nt_to_dict(item::VLFrag)
-    return VLFrag(item.positional, Dict{String,Any}(string(k)=>convert_nt_to_dict(v) for (k,v) in pairs(item.named)) )
+convert_nt_to_dict(item, fragtype) = item
+
+function convert_nt_to_dict(item::NamedTuple, fragtype)
+    return fragtype(Any[], Dict{String,Any}(string(k)=>convert_nt_to_dict(v, fragtype) for (k,v) in pairs(item)))
+end
+
+function convert_nt_to_dict(item::AbstractVegaFragment, fragtype)
+    return fragtype(item.positional, Dict{String,Any}(string(k)=>convert_nt_to_dict(v, fragtype) for (k,v) in pairs(item.named)) )
 end
 
 function walk_dict(f, d, parent)
@@ -146,16 +157,20 @@ replace_remaining_frag(frag) = frag
 
 replace_remaining_frag(frag::Dict) = error("THIS SHOULDN'T HAPPEN $frag")
 
-function replace_remaining_frag(frag::Vector{VLFrag})
+function replace_remaining_frag(frag::Vector{T}) where {T<:AbstractVegaFragment}
     return [replace_remaining_frag(i) for i in frag]
 end
 
-function replace_remaining_frag(frag::VLFrag)
+function replace_remaining_frag(frag::AbstractVegaFragment)
     if !isempty(frag.positional)
         error("There is an unknown positional argument in this spec.")
     else
         return Dict{String,Any}(k=>replace_remaining_frag(v) for (k,v) in frag.named)
     end
+end
+
+function fix_shortcut_level_spec(spec_frag::VGFrag)
+    return spec_frag
 end
 
 function fix_shortcut_level_spec(spec_frag::VLFrag)
@@ -266,7 +281,7 @@ function fix_shortcut_level_spec(spec_frag::VLFrag)
     return VLFrag([], spec)
 end
 
-function convert_vlfrag_tree_to_dict(spec)
+function convert_frag_tree_to_dict(spec::VLFrag)
     # At this point all positional arguments should have been replaced
     # and we can convert everything into a plain Dict structure
     isempty(spec.positional) || error("There shouldn't be any positional argument left.")
@@ -286,6 +301,18 @@ function convert_vlfrag_tree_to_dict(spec)
     return spec_as_dict2
 end
 
+function convert_frag_tree_to_dict(spec::VGFrag)
+    # At this point all positional arguments should have been replaced
+    # and we can convert everything into a plain Dict structure
+    isempty(spec.positional) || error("There shouldn't be any positional argument left.")
+
+    return Dict{String,Any}(k=>replace_remaining_frag(v) for (k,v) in spec.named)
+end
+
 function vlplot(args...;kwargs...)
-    return VLSpec(convert_vlfrag_tree_to_dict(fix_shortcut_level_spec(vlfrag(args...;kwargs...))))
+    return VLSpec(convert_frag_tree_to_dict(fix_shortcut_level_spec(vlfrag(args...;kwargs...))))
+end
+
+function vgplot(args...;kwargs...)
+    return VGSpec(convert_frag_tree_to_dict(fix_shortcut_level_spec(vgfrag(args...;kwargs...))))
 end

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,15 +1,13 @@
 function Base.show(io::IO, m::MIME"text/plain", v::AbstractVegaSpec)
-    printrepr(io, v, indent=4, newlines=true)
+    printrepr(io, v, indent=4, include_data=true)
     return
 end
 
 function Base.show(io::IO, v::AbstractVegaSpec)
-    # This is a hack to detect when we are showing as part of a vector
-    # or matrix
-    if get(io, :typeinfo, Nothing) <: AbstractVegaSpec
-        print(io, summary(v))
+    if !get(io, :compact, true)
+        printrepr(io, v, include_data=true)
     else
-        printrepr(io, v, indent=0, newlines=false)
+        print(io, summary(v))
     end
     return
 end

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,11 +1,11 @@
 function Base.show(io::IO, m::MIME"text/plain", v::AbstractVegaSpec)
-    printrepr(io, v, indent=4, include_data=true)
+    printrepr(io, v, indent=4, include_data=:short)
     return
 end
 
 function Base.show(io::IO, v::AbstractVegaSpec)
     if !get(io, :compact, true)
-        printrepr(io, v, include_data=true)
+        printrepr(io, v, include_data=:short)
     else
         print(io, summary(v))
     end

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -10,9 +10,91 @@ function printrepr(io::IO, v::Union{VLSpec, VGSpec}; kwargs...)
     print(io, "\"\"\"")
 end
 
+function print_datavaluesnode_as_julia(io, it, col_names)
+    print(io, "{values=[")
+
+    for (row_index, row) in enumerate(it)
+        row_index==1 || print(io, ",")
+        print(io, "{")
+
+        for (col_index, col_value) in enumerate(row)
+            col_index==1 || print(io, ",")
+            print(io, col_names[col_index])
+            print(io, "=")
+            print(io, col_value isa DataValue ? get(col_value, nothing) : col_value)
+        end
+
+        print(io, "}")
+    end
+
+    print(io, "]}")
+end
+
+function print_vspec_as_julia(io::IO, d::DataValuesNode, indent)
+    col_names = collect(keys(d.columns))
+    it = TableTraitsUtils.create_tableiterator(collect(values(d.columns)), col_names)
+
+    print_datavaluesnode_as_julia(io, it, col_names)
+end
+
+function print_vspec_as_julia(io::IO, vect::AbstractVector, indent)
+    for (i,v) in enumerate(vect)
+        i>1 && print(io, ",\n")
+        if v isa AbstractDict
+            print(io, " "^indent, "{\n")
+            print_vspec_as_julia(io, v, indent+4)
+            print(io, "\n", " "^indent, "}")
+        elseif v isa AbstractVector
+            print(io, "[\n")
+            print_vspec_as_julia(io, v, indent+4)
+            print(io, "\n", " "^indent, "]")
+        elseif v isa DataValuesNode
+            print_vspec_as_julia(io, v, indent)
+        else
+            print(io, v)
+        end
+    end
+end
+
+function print_vspec_as_julia(io::IO, dict::AbstractDict, indent)
+    for (i,(k,v)) in enumerate(dict)
+        i>1 && print(io, ",\n")
+        print(io, " "^indent, k)
+        print(io, "=")
+        if v isa AbstractDict
+            print(io, "{")
+            println(io)
+            print_vspec_as_julia(io, v, indent+4)
+            print(io, "\n", " "^indent, "}")
+        elseif v isa AbstractVector
+            print(io, "[\n")
+            print_vspec_as_julia(io, v, indent+4)
+            print(io, "\n", " "^indent, "]")
+        elseif v isa AbstractString || v isa Symbol
+            print(io, "\"")
+            print(io, string(v))
+            print(io, "\"")
+        elseif v isa DataValuesNode
+            print_vspec_as_julia(io, v, indent)
+        else
+            print(io, v)
+        end
+    end
+end
+
+function printrepr2(io::IO, v::AbstractVegaSpec)
+    println(io, v isa VGSpec ? "@vgplot(" : "@vlplot(")
+    print_vspec_as_julia(io, getparams(v), 4)    
+    println(io, "\n)")
+end
+
+function printrepr2(v::AbstractVegaSpec)
+    printrepr2(stdout, v)
+end
+
 function Base.show(io::IO, m::MIME"text/plain", v::AbstractVegaSpec)
     if !get(io, :compact, true) && v isa Union{VLSpec, VGSpec}
-        printrepr(io, v)
+        printrepr2(io, v)
     else
         print(io, summary(v))
     end

--- a/src/rendering/to_julia.jl
+++ b/src/rendering/to_julia.jl
@@ -1,0 +1,105 @@
+function print_datavaluesnode_as_julia(io, it, col_names)
+    print(io, "{values=[")
+
+    for (row_index, row) in enumerate(it)
+        row_index==1 || print(io, ",")
+        print(io, "{")
+
+        for (col_index, col_value) in enumerate(row)
+            col_index==1 || print(io, ",")
+            print(io, col_names[col_index])
+            print(io, "=")
+            print(io, col_value isa DataValue ? get(col_value, nothing) : col_value)
+        end
+
+        print(io, "}")
+    end
+
+    print(io, "]}")
+end
+
+function print_vspec_as_julia(io::IO, d::DataValuesNode, indent, indent_level, newlines, include_data)
+    col_names = collect(keys(d.columns))
+    it = TableTraitsUtils.create_tableiterator(collect(values(d.columns)), col_names)
+
+    print_datavaluesnode_as_julia(io, it, col_names)
+end
+
+function print_vspec_as_julia(io::IO, vect::AbstractVector, indent, indent_level, newlines, include_data)    
+    for (i,v) in enumerate(vect)
+        i>1 && print(io, ",", newlines ? "\n" : "")
+        if v isa AbstractDict
+            print(io, " "^(indent*indent_level), "{")
+            newlines && println(io)
+            print_vspec_as_julia(io, v, indent, indent_level+1, newlines, include_data)
+            newlines && println(io)
+            print(io, " "^(indent*indent_level), "}")
+        elseif v isa AbstractVector
+            print(io, "[")
+            newlines && println(io)
+            print_vspec_as_julia(io, v, indent, indent_level+1, newlines, include_data)
+            newlines && println(io)
+            print(io, " "^(indent*indent_level), "]")
+        elseif v isa DataValuesNode
+            print_vspec_as_julia(io, v, indent, indent_level, newlines, include_data)
+        else
+            print(io, v)
+        end
+    end
+end
+
+function print_vspec_as_julia(io::IO, dict::AbstractDict, indent, indent_level, newlines, include_data)
+    dict = include_data ? dict : Dict{String,Any}(i for i in dict if i[1]!="data")
+    for (i,(k,v)) in enumerate(dict)
+        i>1 && print(io, ",", newlines ? "\n" : "")
+        print(io, " "^(indent*indent_level), k)
+        print(io, "=")
+        if v isa AbstractDict
+            print(io, "{")
+            newlines && println(io)
+            print_vspec_as_julia(io, v, indent, indent_level+1, newlines, include_data)
+            newlines && println(io)
+            print(io, " "^(indent*indent_level), "}")
+        elseif v isa AbstractVector
+            print(io, "[")
+            newlines && println(io)
+            print_vspec_as_julia(io, v, indent, indent_level+1, newlines, include_data)
+            newlines && println(io)
+            print(io, " "^(indent*indent_level), "]")
+        elseif v isa AbstractString || v isa Symbol
+            print(io, "\"")
+            print(io, string(v))
+            print(io, "\"")
+        elseif v isa DataValuesNode
+            print_vspec_as_julia(io, v, indent, indent_level+1, newlines, include_data)
+        else
+            print(io, v)
+        end
+    end
+end
+
+"""
+    printrepr(io, v::AbstractVegaSpec; indent=4, newlines=true, include_data=true)
+
+Print representation of a Vega or VegaLite spec `v` parsable by Julia.
+The `include_data` keyword controls whether the `data` element is included
+in the output. `indent` and `newlines` control whether the output is printed
+with indentation and newlines or not.
+"""
+function printrep end
+
+function printrepr(io::IO, v::VGSpec; indent=4, newlines=true, include_data=true)
+    print(io, "@vgplot(")
+    newlines && println(io)
+    print_vspec_as_julia(io, getparams(v), indent, 1, newlines, include_data)
+    newlines && println(io)
+    print(io, ")")
+end
+
+function printrepr(io::IO, v::VLSpec; indent=4, newlines=true, include_data=true)
+    print(io, "@vlplot(")
+    newlines && println(io)
+    print_vspec_as_julia(io, getparams(v), indent, 1, newlines, include_data)
+    newlines && println(io)
+    print(io, ")")
+end

--- a/src/rendering/to_julia.jl
+++ b/src/rendering/to_julia.jl
@@ -79,16 +79,20 @@ function print_vspec_as_julia(io::IO, dict::AbstractDict, indent, indent_level, 
 end
 
 """
-    printrepr(io, v::AbstractVegaSpec; indent=4, newlines=true, include_data=true)
+    printrepr(io, v::AbstractVegaSpec; indent=nothing, include_data=false)
 
 Print representation of a Vega or VegaLite spec `v` parsable by Julia.
 The `include_data` keyword controls whether the `data` element is included
-in the output. `indent` and `newlines` control whether the output is printed
-with indentation and newlines or not.
+in the output. `indent` controls whether the code is printed in one line
+(indent=nothing), or as multiple lines with indentation (by passing an
+`Int` to `indent`).
 """
 function printrep end
 
-function printrepr(io::IO, v::VGSpec; indent=4, newlines=true, include_data=true)
+function printrepr(io::IO, v::VGSpec; indent=nothing, include_data=false)
+    newlines = indent===nothing ? false : true
+    indent = indent===nothing ? 0 : indent
+
     print(io, "@vgplot(")
     newlines && println(io)
     print_vspec_as_julia(io, getparams(v), indent, 1, newlines, include_data)
@@ -96,7 +100,10 @@ function printrepr(io::IO, v::VGSpec; indent=4, newlines=true, include_data=true
     print(io, ")")
 end
 
-function printrepr(io::IO, v::VLSpec; indent=4, newlines=true, include_data=true)
+function printrepr(io::IO, v::VLSpec; indent=nothing, include_data=false)
+    newlines = indent===nothing ? false : true
+    indent = indent===nothing ? 0 : indent
+
     print(io, "@vlplot(")
     newlines && println(io)
     print_vspec_as_julia(io, getparams(v), indent, 1, newlines, include_data)

--- a/src/rendering/to_julia.jl
+++ b/src/rendering/to_julia.jl
@@ -22,7 +22,11 @@ function print_vspec_as_julia(io::IO, d::DataValuesNode, indent, indent_level, n
     col_names = collect(keys(d.columns))
     it = TableTraitsUtils.create_tableiterator(collect(values(d.columns)), col_names)
 
-    print_datavaluesnode_as_julia(io, it, col_names)
+    if include_data==:short
+        print(io, "...")
+    else
+        print_datavaluesnode_as_julia(io, it, col_names)
+    end
 end
 
 function print_vspec_as_julia(io::IO, vect::AbstractVector, indent, indent_level, newlines, include_data)    
@@ -49,7 +53,7 @@ function print_vspec_as_julia(io::IO, vect::AbstractVector, indent, indent_level
 end
 
 function print_vspec_as_julia(io::IO, dict::AbstractDict, indent, indent_level, newlines, include_data)
-    dict = include_data ? dict : Dict{String,Any}(i for i in dict if i[1]!="data")
+    dict = (include_data==:short || include_data) ? dict : Dict{String,Any}(i for i in dict if i[1]!="data")
     for (i,(k,v)) in enumerate(dict)
         i>1 && print(io, ",", newlines ? "\n" : "")
         print(io, " "^(indent*indent_level), k)

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -18,7 +18,7 @@ function augment_encoding_type(x::Dict, data::DataValuesNode)
     if !haskey(x, "type") && !haskey(x, "aggregate") && haskey(x, "field") && haskey(data.columns, Symbol(x["field"]))
         new_x = copy(x)
 
-        jl_type = data.columns[Symbol(x["field"])]
+        jl_type = eltype(data.columns[Symbol(x["field"])])
 
         if jl_type <: DataValues.DataValue
             jl_type = eltype(jl_type)

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -6,9 +6,13 @@ using VegaLite
 vl = @vlplot(:point)
 vg = VegaLite.VGSpec(Dict{String,Any}())
 
-@test sprint(show, "text/plain", vl) == "VegaLite.VLSpec"
+@test sprint(show, vl) == "VegaLite.VLSpec"
 
-@test sprint(show, "text/plain", vg) == "VegaLite.VGSpec"
+@test sprint(show, "text/plain", vl) == "@vlplot(\n    mark=\"point\"\n)"
+
+@test sprint(show, vg) == "VegaLite.VGSpec"
+
+@test sprint(show, "text/plain", vg) == "@vgplot(\n\n)"
 
 @test_throws ArgumentError sprint(show, "image/svg+xml", @vlplot())
 


### PR DESCRIPTION
This adds `@vgplot`, `@vgfrag`, `vgplot` and `vgfrag`. They work exactly like their vega-lite counterparts.

This PR also changes (again) how data is handled. It is now stored as columns, right until we serialize as JSON. I have one more step on that part that will hopefully (in some scenarios) allow us to really minimize the copying of data we need to do.

I also added some code that output a vega-lite and vega spec as Julia code that uses the `@vlplot` and `@vgplot` command. @tkf, right now we seem to have a `Base.show` method that prints julia code when certain context things are set. I think you added that. Is that the official Julia way to do this? As a user, is there some simple way for me to take `x` and say "give me a julia code representation of that?". The goal of all of this is that we can convert the vega examples super quickly, I really want us to get to a point where we can do `load("foo.vega") |> save("foo.jl")`.

And I fixed a completely unrelated bug because I discovered it :)