### PR TITLE
Add save as HTML file support

### DIFF
--- a/docs/src/userguide/vlspec.md
+++ b/docs/src/userguide/vlspec.md
@@ -162,7 +162,7 @@ Simply viewing plots should work out of the box in all known Julia environments.
 
 ## Saving plots
 
-[VegaLite.jl](https://github.com/queryverse/VegaLite.jl) plots can be saved as [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics), [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics), [PDF](https://en.wikipedia.org/wiki/PDF) and [EPS](https://en.wikipedia.org/wiki/Encapsulated_PostScript) files. You can save a plot by calling the `save` function:
+[VegaLite.jl](https://github.com/queryverse/VegaLite.jl) plots can be saved as [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics), [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics), [PDF](https://en.wikipedia.org/wiki/PDF), [EPS](https://en.wikipedia.org/wiki/Encapsulated_PostScript) and HTML files. You can save a plot by calling the `save` function:
 
 ```julia
 using VegaLite, VegaDatasets
@@ -178,8 +178,11 @@ save("figure.svg", p)
 # Save as PDF file
 save("figure.pdf", p)
 
-# Save EPS PNG file
+# Save EPS file
 save("figure.eps", p)
+
+# Save HTML file
+save("figure.html", p)
 ```
 
 You can also use the `|>` operator with the `save` function:

--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -12,10 +12,10 @@ asset(url...) = normpath(joinpath(vegaliate_app_path, "minified", url...))
 Creates standalone html file for showing the plot (typically in a browser tab).
 VegaLite js files are references to local copies.
 """
-function writehtml_full(io::IO, spec::String; title="VegaLite plot")
+function writehtml_full(io::IO, spec::VLSpec; title="VegaLite plot")
   divid = "vg" * randstring(3)
 
-  println(io,
+  print(io,
   """
   <html>
     <head>
@@ -46,8 +46,12 @@ function writehtml_full(io::IO, spec::String; title="VegaLite plot")
         actions: $ACTIONSLINKS
       }
 
-      var spec = $spec
+      var spec = """)
 
+  our_json_print(io, spec)
+  println(io)
+
+  println(io, """
       vegaEmbed('#$divid', spec, opt);
 
     </script>
@@ -56,7 +60,7 @@ function writehtml_full(io::IO, spec::String; title="VegaLite plot")
   """)
 end
 
-function writevghtml_full(io::IO, spec::String; title="Vega plot")
+function writehtml_full(io::IO, spec::VGSpec; title="Vega plot")
   divid = "vg" * randstring(3)
 
   println(io,
@@ -89,8 +93,12 @@ function writevghtml_full(io::IO, spec::String; title="Vega plot")
         actions: $ACTIONSLINKS
       }
 
-      var spec = $spec
+      var spec = """)
+      
+  our_json_print(io, spec)
+  println(io)
 
+  println(io, """
       vegaEmbed('#$divid', spec, opt);
 
     </script>
@@ -99,7 +107,7 @@ function writevghtml_full(io::IO, spec::String; title="Vega plot")
   """)
 end
 
-function writehtml_full(spec::String; title="VegaLite plot")
+function writehtml_full(spec::VLSpec; title="VegaLite plot")
   tmppath = string(tempname(), ".vegalite.html")
 
   open(tmppath, "w") do io
@@ -109,11 +117,11 @@ function writehtml_full(spec::String; title="VegaLite plot")
   tmppath
 end
 
-function write_vg_html_full(spec::String; title="Vega plot")
+function writehtml_full(spec::VGSpec; title="Vega plot")
   tmppath = string(tempname(), ".vega.html")
 
   open(tmppath, "w") do io
-    writevghtml_full(io, spec, title=title)
+    writehtml_full(io, spec, title=title)
   end
 
   tmppath
@@ -202,11 +210,11 @@ end
 
 function Base.display(d::REPL.REPLDisplay, plt::VLSpec)
   # checkplot(plt)
-  tmppath = writehtml_full(sprint(our_json_print, plt))
+  tmppath = writehtml_full(plt)
   launch_browser(tmppath) # Open the browser
 end
 
 function Base.display(d::REPL.REPLDisplay, plt::VGSpec)
-  tmppath = write_vg_html_full(sprint(our_json_print, plt))
+  tmppath = writehtml_full(plt)
   launch_browser(tmppath) # Open the browser
 end

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -217,3 +217,11 @@ function Base.show(io::IO, m::MIME"image/png", v::VGSpec)
         Cairo.write_to_png(cs,io)
     end
 end
+
+function Base.show(io::IO, m::MIME"application/vnd.julia.fileio.htmlfile", v::VegaLite.VLSpec)
+    writehtml_full(io, v)
+end
+
+function Base.show(io::IO, m::MIME"application/vnd.julia.fileio.htmlfile", v::VegaLite.VGSpec)
+    writehtml_full(io, v)
+end


### PR DESCRIPTION
Fixes #184. Fixes #198.

This will only fully work once https://github.com/JuliaIO/FileIO.jl/pull/250 is merged and a new version of FileIO.jl is tagged.

Also makes the whole HTML export code a bit more efficient by avoiding some allocations.