### PR TITLE
Add Isotype Dot Plots

### DIFF
--- a/docs/src/examples/examples_barchartshistograms.md
+++ b/docs/src/examples/examples_barchartshistograms.md
@@ -185,7 +185,7 @@ using VegaLite, DataFrames
 
 data = DataFrame(
     question=["Question $(div(i,5)+1)" for i in 0:39],
-    typ=repeat(["Strongly disagree", "Disagree", "Neither agree nor disagree",
+    type=repeat(["Strongly disagree", "Disagree", "Neither agree nor disagree",
         "Agree", "Strongly agree"],outer=8),
     value=[24, 294, 594, 1927, 376, 2, 2, 0, 7, 11, 2, 0, 2, 4, 2, 0, 2, 1, 7,
         6, 0, 1, 3, 16, 4, 1, 1, 2, 9, 3, 0, 0, 1, 4, 0, 0, 0, 0, 0, 2],
@@ -226,7 +226,7 @@ data |> @vlplot(
                 "Strongly agree"
             ],
             range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"],
-            typ=:ordinal
+            type=:ordinal
         }
     }
 )
@@ -280,34 +280,32 @@ df |> @vlplot(
     height=200,
     width=800,
     mark={:point, filled=true},
-    enc={
-        x={"col:o", axis=nothing},
-        y={"animal:o", axis=nothing},
-        row={"country:n", header={title=nothing}},
-        shape={
-            "animal:n",
-            scale={
-                domain=[ "person", "cattle", "pigs", "sheep" ],
-                range=[ personSVGPath, cattleSVGPath, pigsSVGPath, sheepSVGPath ]
-            },
-            legend=nothing
+    x={"col:o", axis=nothing},
+    y={"animal:o", axis=nothing},
+    row={"country:n", header={title=nothing}},
+    shape={
+        "animal:n",
+        scale={
+            domain=[ "person", "cattle", "pigs", "sheep" ],
+            range=[ personSVGPath, cattleSVGPath, pigsSVGPath, sheepSVGPath ]
         },
-        color={
-            "animal:n",
-            legend=nothing,
-            scale={
-                domain=[ "person", "cattle", "pigs", "sheep" ],
-                range=[
-                    "rgb(162,160,152)",
-                    "rgb(194,81,64)",
-                    "rgb(93,93,93)",
-                    "rgb(91,131,149)"
-                ]
-            }
-        },
-        opacity={ value=1 },
-        size={ value=200 }
-    }
+        legend=nothing
+    },
+    color={
+        "animal:n",
+        legend=nothing,
+        scale={
+            domain=[ "person", "cattle", "pigs", "sheep" ],
+            range=[
+                "rgb(162,160,152)",
+                "rgb(194,81,64)",
+                "rgb(93,93,93)",
+                "rgb(91,131,149)"
+            ]
+        }
+    },
+    opacity={ value=1 },
+    size={ value=200 }
 )
 ```
 
@@ -338,13 +336,11 @@ df |> @vlplot(
         {window=[{op=:rank, as=:rank}], groupby=[:country, :animal]}
     ],
     mark={:text, baseline=:middle},
-    enc={
-        x={"rank:o", axis=nothing},
-        y={"animal:n", axis=nothing, sort=nothing},
-        row={"country:n", header={title=nothing}},
-        text="emoji:n",
-        size={ value=65 }
-    }
+    x={"rank:o", axis=nothing},
+    y={"animal:n", axis=nothing, sort=nothing},
+    row={"country:n", header={title=nothing}},
+    text="emoji:n",
+    size={ value=65 }
 )
 ```
 

--- a/docs/src/examples/examples_barchartshistograms.md
+++ b/docs/src/examples/examples_barchartshistograms.md
@@ -185,7 +185,7 @@ using VegaLite, DataFrames
 
 data = DataFrame(
     question=["Question $(div(i,5)+1)" for i in 0:39],
-    type=repeat(["Strongly disagree", "Disagree", "Neither agree nor disagree",
+    typ=repeat(["Strongly disagree", "Disagree", "Neither agree nor disagree",
         "Agree", "Strongly agree"],outer=8),
     value=[24, 294, 594, 1927, 376, 2, 2, 0, 7, 11, 2, 0, 2, 4, 2, 0, 2, 1, 7,
         6, 0, 1, 3, 16, 4, 1, 1, 2, 9, 3, 0, 0, 1, 4, 0, 0, 0, 0, 0, 2],
@@ -226,7 +226,7 @@ data |> @vlplot(
                 "Strongly agree"
             ],
             range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"],
-            type=:ordinal
+            typ=:ordinal
         }
     }
 )
@@ -259,3 +259,94 @@ using VegaLite
     text="b:q"
 )
 ```
+
+## Isotype Dot Plot
+
+```@example
+using VegaLite, DataFrames
+
+df=DataFrame(
+    country=["Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States"],
+    animal=["cattle","cattle","cattle","pigs","pigs","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","cattle","cattle","cattle","cattle","cattle","cattle","cattle","cattle","cattle","pigs","pigs","pigs","pigs","pigs","pigs","sheep","sheep","sheep","sheep","sheep","sheep","sheep"],
+    col=[3,2,1,2,1,10,9,8,7,6,5,4,3,2,1,9,8,7,6,5,4,3,2,1,6,5,4,3,2,1,7,6,5,4,3,2,1]
+)
+personSVGPath="M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z"
+cattleSVGPath="M4 -2c0 0 0.9 -0.7 1.1 -0.8c0.1 -0.1 -0.1 0.5 -0.3 0.7c-0.2 0.2 1.1 1.1 1.1 1.2c0 0.2 -0.2 0.8 -0.4 0.7c-0.1 0 -0.8 -0.3 -1.3 -0.2c-0.5 0.1 -1.3 1.6 -1.5 2c-0.3 0.4 -0.6 0.4 -0.6 0.4c0 0.1 0.3 1.7 0.4 1.8c0.1 0.1 -0.4 0.1 -0.5 0c0 0 -0.6 -1.9 -0.6 -1.9c-0.1 0 -0.3 -0.1 -0.3 -0.1c0 0.1 -0.5 1.4 -0.4 1.6c0.1 0.2 0.1 0.3 0.1 0.3c0 0 -0.4 0 -0.4 0c0 0 -0.2 -0.1 -0.1 -0.3c0 -0.2 0.3 -1.7 0.3 -1.7c0 0 -2.8 -0.9 -2.9 -0.8c-0.2 0.1 -0.4 0.6 -0.4 1c0 0.4 0.5 1.9 0.5 1.9l-0.5 0l-0.6 -2l0 -0.6c0 0 -1 0.8 -1 1c0 0.2 -0.2 1.3 -0.2 1.3c0 0 0.3 0.3 0.2 0.3c0 0 -0.5 0 -0.5 0c0 0 -0.2 -0.2 -0.1 -0.4c0 -0.1 0.2 -1.6 0.2 -1.6c0 0 0.5 -0.4 0.5 -0.5c0 -0.1 0 -2.7 -0.2 -2.7c-0.1 0 -0.4 2 -0.4 2c0 0 0 0.2 -0.2 0.5c-0.1 0.4 -0.2 1.1 -0.2 1.1c0 0 -0.2 -0.1 -0.2 -0.2c0 -0.1 -0.1 -0.7 0 -0.7c0.1 -0.1 0.3 -0.8 0.4 -1.4c0 -0.6 0.2 -1.3 0.4 -1.5c0.1 -0.2 0.6 -0.4 0.6 -0.4z"
+pigsSVGPath="M1.2 -2c0 0 0.7 0 1.2 0.5c0.5 0.5 0.4 0.6 0.5 0.6c0.1 0 0.7 0 0.8 0.1c0.1 0 0.2 0.2 0.2 0.2c0 0 -0.6 0.2 -0.6 0.3c0 0.1 0.4 0.9 0.6 0.9c0.1 0 0.6 0 0.6 0.1c0 0.1 0 0.7 -0.1 0.7c-0.1 0 -1.2 0.4 -1.5 0.5c-0.3 0.1 -1.1 0.5 -1.1 0.7c-0.1 0.2 0.4 1.2 0.4 1.2l-0.4 0c0 0 -0.4 -0.8 -0.4 -0.9c0 -0.1 -0.1 -0.3 -0.1 -0.3l-0.2 0l-0.5 1.3l-0.4 0c0 0 -0.1 -0.4 0 -0.6c0.1 -0.1 0.3 -0.6 0.3 -0.7c0 0 -0.8 0 -1.5 -0.1c-0.7 -0.1 -1.2 -0.3 -1.2 -0.2c0 0.1 -0.4 0.6 -0.5 0.6c0 0 0.3 0.9 0.3 0.9l-0.4 0c0 0 -0.4 -0.5 -0.4 -0.6c0 -0.1 -0.2 -0.6 -0.2 -0.5c0 0 -0.4 0.4 -0.6 0.4c-0.2 0.1 -0.4 0.1 -0.4 0.1c0 0 -0.1 0.6 -0.1 0.6l-0.5 0l0 -1c0 0 0.5 -0.4 0.5 -0.5c0 -0.1 -0.7 -1.2 -0.6 -1.4c0.1 -0.1 0.1 -1.1 0.1 -1.1c0 0 -0.2 0.1 -0.2 0.1c0 0 0 0.9 0 1c0 0.1 -0.2 0.3 -0.3 0.3c-0.1 0 0 -0.5 0 -0.9c0 -0.4 0 -0.4 0.2 -0.6c0.2 -0.2 0.6 -0.3 0.8 -0.8c0.3 -0.5 1 -0.6 1 -0.6z"
+sheepSVGPath="M-4.1 -0.5c0.2 0 0.2 0.2 0.5 0.2c0.3 0 0.3 -0.2 0.5 -0.2c0.2 0 0.2 0.2 0.4 0.2c0.2 0 0.2 -0.2 0.5 -0.2c0.2 0 0.2 0.2 0.4 0.2c0.2 0 0.2 -0.2 0.4 -0.2c0.1 0 0.2 0.2 0.4 0.1c0.2 0 0.2 -0.2 0.4 -0.3c0.1 0 0.1 -0.1 0.4 0c0.3 0 0.3 -0.4 0.6 -0.4c0.3 0 0.6 -0.3 0.7 -0.2c0.1 0.1 1.4 1 1.3 1.4c-0.1 0.4 -0.3 0.3 -0.4 0.3c-0.1 0 -0.5 -0.4 -0.7 -0.2c-0.3 0.2 -0.1 0.4 -0.2 0.6c-0.1 0.1 -0.2 0.2 -0.3 0.4c0 0.2 0.1 0.3 0 0.5c-0.1 0.2 -0.3 0.2 -0.3 0.5c0 0.3 -0.2 0.3 -0.3 0.6c-0.1 0.2 0 0.3 -0.1 0.5c-0.1 0.2 -0.1 0.2 -0.2 0.3c-0.1 0.1 0.3 1.1 0.3 1.1l-0.3 0c0 0 -0.3 -0.9 -0.3 -1c0 -0.1 -0.1 -0.2 -0.3 -0.2c-0.2 0 -0.3 0.1 -0.4 0.4c0 0.3 -0.2 0.8 -0.2 0.8l-0.3 0l0.3 -1c0 0 0.1 -0.6 -0.2 -0.5c-0.3 0.1 -0.2 -0.1 -0.4 -0.1c-0.2 -0.1 -0.3 0.1 -0.4 0c-0.2 -0.1 -0.3 0.1 -0.5 0c-0.2 -0.1 -0.1 0 -0.3 0.3c-0.2 0.3 -0.4 0.3 -0.4 0.3l0.2 1.1l-0.3 0l-0.2 -1.1c0 0 -0.4 -0.6 -0.5 -0.4c-0.1 0.3 -0.1 0.4 -0.3 0.4c-0.1 -0.1 -0.2 1.1 -0.2 1.1l-0.3 0l0.2 -1.1c0 0 -0.3 -0.1 -0.3 -0.5c0 -0.3 0.1 -0.5 0.1 -0.7c0.1 -0.2 -0.1 -1 -0.2 -1.1c-0.1 -0.2 -0.2 -0.8 -0.2 -0.8c0 0 -0.1 -0.5 0.4 -0.8z"
+
+df |> @vlplot(
+    config={view={stroke=nothing}},
+    height=200,
+    width=800,
+    mark={:point, filled=true},
+    enc={
+        x={"col:o", axis=nothing},
+        y={"animal:o", axis=nothing},
+        row={"country:n", header={title=nothing}},
+        shape={
+            "animal:n",
+            scale={
+                domain=[ "person", "cattle", "pigs", "sheep" ],
+                range=[ personSVGPath, cattleSVGPath, pigsSVGPath, sheepSVGPath ]
+            },
+            legend=nothing
+        },
+        color={
+            "animal:n",
+            legend=nothing,
+            scale={
+                domain=[ "person", "cattle", "pigs", "sheep" ],
+                range=[
+                    "rgb(162,160,152)",
+                    "rgb(194,81,64)",
+                    "rgb(93,93,93)",
+                    "rgb(91,131,149)"
+                ]
+            }
+        },
+        opacity={ value=1 },
+        size={ value=200 }
+    }
+)
+```
+
+## Isotype Dot Plot with Emoji
+
+```@example
+using VegaLite, DataFrames
+
+df=DataFrame(
+    country=["Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","Great,Britain","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States","United,States"],
+    animal=["cattle","cattle","cattle","pigs","pigs","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","sheep","cattle","cattle","cattle","cattle","cattle","cattle","cattle","cattle","cattle","pigs","pigs","pigs","pigs","pigs","pigs","sheep","sheep","sheep","sheep","sheep","sheep","sheep"],
+    col=[3,2,1,2,1,10,9,8,7,6,5,4,3,2,1,9,8,7,6,5,4,3,2,1,6,5,4,3,2,1,7,6,5,4,3,2,1]
+)
+personSVGPath="M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z"
+cattleSVGPath="M4 -2c0 0 0.9 -0.7 1.1 -0.8c0.1 -0.1 -0.1 0.5 -0.3 0.7c-0.2 0.2 1.1 1.1 1.1 1.2c0 0.2 -0.2 0.8 -0.4 0.7c-0.1 0 -0.8 -0.3 -1.3 -0.2c-0.5 0.1 -1.3 1.6 -1.5 2c-0.3 0.4 -0.6 0.4 -0.6 0.4c0 0.1 0.3 1.7 0.4 1.8c0.1 0.1 -0.4 0.1 -0.5 0c0 0 -0.6 -1.9 -0.6 -1.9c-0.1 0 -0.3 -0.1 -0.3 -0.1c0 0.1 -0.5 1.4 -0.4 1.6c0.1 0.2 0.1 0.3 0.1 0.3c0 0 -0.4 0 -0.4 0c0 0 -0.2 -0.1 -0.1 -0.3c0 -0.2 0.3 -1.7 0.3 -1.7c0 0 -2.8 -0.9 -2.9 -0.8c-0.2 0.1 -0.4 0.6 -0.4 1c0 0.4 0.5 1.9 0.5 1.9l-0.5 0l-0.6 -2l0 -0.6c0 0 -1 0.8 -1 1c0 0.2 -0.2 1.3 -0.2 1.3c0 0 0.3 0.3 0.2 0.3c0 0 -0.5 0 -0.5 0c0 0 -0.2 -0.2 -0.1 -0.4c0 -0.1 0.2 -1.6 0.2 -1.6c0 0 0.5 -0.4 0.5 -0.5c0 -0.1 0 -2.7 -0.2 -2.7c-0.1 0 -0.4 2 -0.4 2c0 0 0 0.2 -0.2 0.5c-0.1 0.4 -0.2 1.1 -0.2 1.1c0 0 -0.2 -0.1 -0.2 -0.2c0 -0.1 -0.1 -0.7 0 -0.7c0.1 -0.1 0.3 -0.8 0.4 -1.4c0 -0.6 0.2 -1.3 0.4 -1.5c0.1 -0.2 0.6 -0.4 0.6 -0.4z"
+pigsSVGPath="M1.2 -2c0 0 0.7 0 1.2 0.5c0.5 0.5 0.4 0.6 0.5 0.6c0.1 0 0.7 0 0.8 0.1c0.1 0 0.2 0.2 0.2 0.2c0 0 -0.6 0.2 -0.6 0.3c0 0.1 0.4 0.9 0.6 0.9c0.1 0 0.6 0 0.6 0.1c0 0.1 0 0.7 -0.1 0.7c-0.1 0 -1.2 0.4 -1.5 0.5c-0.3 0.1 -1.1 0.5 -1.1 0.7c-0.1 0.2 0.4 1.2 0.4 1.2l-0.4 0c0 0 -0.4 -0.8 -0.4 -0.9c0 -0.1 -0.1 -0.3 -0.1 -0.3l-0.2 0l-0.5 1.3l-0.4 0c0 0 -0.1 -0.4 0 -0.6c0.1 -0.1 0.3 -0.6 0.3 -0.7c0 0 -0.8 0 -1.5 -0.1c-0.7 -0.1 -1.2 -0.3 -1.2 -0.2c0 0.1 -0.4 0.6 -0.5 0.6c0 0 0.3 0.9 0.3 0.9l-0.4 0c0 0 -0.4 -0.5 -0.4 -0.6c0 -0.1 -0.2 -0.6 -0.2 -0.5c0 0 -0.4 0.4 -0.6 0.4c-0.2 0.1 -0.4 0.1 -0.4 0.1c0 0 -0.1 0.6 -0.1 0.6l-0.5 0l0 -1c0 0 0.5 -0.4 0.5 -0.5c0 -0.1 -0.7 -1.2 -0.6 -1.4c0.1 -0.1 0.1 -1.1 0.1 -1.1c0 0 -0.2 0.1 -0.2 0.1c0 0 0 0.9 0 1c0 0.1 -0.2 0.3 -0.3 0.3c-0.1 0 0 -0.5 0 -0.9c0 -0.4 0 -0.4 0.2 -0.6c0.2 -0.2 0.6 -0.3 0.8 -0.8c0.3 -0.5 1 -0.6 1 -0.6z"
+sheepSVGPath="M-4.1 -0.5c0.2 0 0.2 0.2 0.5 0.2c0.3 0 0.3 -0.2 0.5 -0.2c0.2 0 0.2 0.2 0.4 0.2c0.2 0 0.2 -0.2 0.5 -0.2c0.2 0 0.2 0.2 0.4 0.2c0.2 0 0.2 -0.2 0.4 -0.2c0.1 0 0.2 0.2 0.4 0.1c0.2 0 0.2 -0.2 0.4 -0.3c0.1 0 0.1 -0.1 0.4 0c0.3 0 0.3 -0.4 0.6 -0.4c0.3 0 0.6 -0.3 0.7 -0.2c0.1 0.1 1.4 1 1.3 1.4c-0.1 0.4 -0.3 0.3 -0.4 0.3c-0.1 0 -0.5 -0.4 -0.7 -0.2c-0.3 0.2 -0.1 0.4 -0.2 0.6c-0.1 0.1 -0.2 0.2 -0.3 0.4c0 0.2 0.1 0.3 0 0.5c-0.1 0.2 -0.3 0.2 -0.3 0.5c0 0.3 -0.2 0.3 -0.3 0.6c-0.1 0.2 0 0.3 -0.1 0.5c-0.1 0.2 -0.1 0.2 -0.2 0.3c-0.1 0.1 0.3 1.1 0.3 1.1l-0.3 0c0 0 -0.3 -0.9 -0.3 -1c0 -0.1 -0.1 -0.2 -0.3 -0.2c-0.2 0 -0.3 0.1 -0.4 0.4c0 0.3 -0.2 0.8 -0.2 0.8l-0.3 0l0.3 -1c0 0 0.1 -0.6 -0.2 -0.5c-0.3 0.1 -0.2 -0.1 -0.4 -0.1c-0.2 -0.1 -0.3 0.1 -0.4 0c-0.2 -0.1 -0.3 0.1 -0.5 0c-0.2 -0.1 -0.1 0 -0.3 0.3c-0.2 0.3 -0.4 0.3 -0.4 0.3l0.2 1.1l-0.3 0l-0.2 -1.1c0 0 -0.4 -0.6 -0.5 -0.4c-0.1 0.3 -0.1 0.4 -0.3 0.4c-0.1 -0.1 -0.2 1.1 -0.2 1.1l-0.3 0l0.2 -1.1c0 0 -0.3 -0.1 -0.3 -0.5c0 -0.3 0.1 -0.5 0.1 -0.7c0.1 -0.2 -0.1 -1 -0.2 -1.1c-0.1 -0.2 -0.2 -0.8 -0.2 -0.8c0 0 -0.1 -0.5 0.4 -0.8z"
+
+df |> @vlplot(
+    config={view={stroke=nothing}},
+    height=200,
+    width=800,
+    transform= [
+        {
+            calculate="{'cattle': '🐄', 'pigs': '🐖', 'sheep': '🐏'}[datum.animal]",
+            as=:emoji
+        },
+        {window=[{op=:rank, as=:rank}], groupby=[:country, :animal]}
+    ],
+    mark={:text, baseline=:middle},
+    enc={
+        x={"rank:o", axis=nothing},
+        y={"animal:n", axis=nothing, sort=nothing},
+        row={"country:n", header={title=nothing}},
+        text="emoji:n",
+        size={ value=65 }
+    }
+)
+```
+
+
+


### PR DESCRIPTION
Added the two examples with sheep and pigs.

The current examples at https://vega.github.io/vega-lite/examples/ has subsections
- Bar Charts
- Histograms, Density Plots, and Dot Plots

In the VegaLite examples we have just the section(submenu):
- Bar Charts & Histograms

For the next PR should I split the current file
- examples_barchartshistograms.md

into two new files
- examples_barcharts.md
- examples_histograms.md

to reflect the origin?

