### PR TITLE
Add support for Juno MIME type

### DIFF
--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -225,3 +225,11 @@ end
 function Base.show(io::IO, m::MIME"application/vnd.julia.fileio.htmlfile", v::VegaLite.VGSpec)
     writehtml_full(io, v)
 end
+
+function Base.show(io::IO, m::MIME"application/prs.juno.plotpane+html", v::VLSpec)
+    writehtml_full(io, v)
+end
+
+function Base.show(io::IO, m::MIME"application/prs.juno.plotpane+html", v::VGSpec)
+    writehtml_full(io, v)
+end


### PR DESCRIPTION
Fixes #90.

Except, it doesn't :) As far as I can tell this seems to work on the VegaLite.jl side of things, but then nothing shows up in Juno. @pfitzseb, any idea?

The code right now emits a full HTML document, i.e. including a starting `<html>` tag. Do we maybe just need a fragment?

PS: Oh, and testing this is kind of painful because Atom.jl/Juno.jl seems to downgrade a lot of my other stuff... I think it is because it require CSTParser <2?