### PR TITLE
Properly access RENDERER and ACTIONSLINKS from Vega

### DIFF
--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -42,8 +42,8 @@ function writehtml_full(io::IO, spec::VLSpec; title="VegaLite plot")
 
       var opt = {
         mode: "vega-lite",
-        renderer: "$RENDERER",
-        actions: $ACTIONSLINKS
+        renderer: "$(Vega.RENDERER)",
+        actions: $(Vega.ACTIONSLINKS)
       }
 
       var spec = """)
@@ -121,8 +121,8 @@ function writehtml_partial(io::IO, spec::String; title="VegaLite plot")
 
       var opt = {
         mode: "vega-lite",
-        renderer: "$RENDERER",
-        actions: $ACTIONSLINKS
+        renderer: "$(Vega.RENDERER)",
+        actions: $(Vega.ACTIONSLINKS)
       }
 
       vg_embed("#$divid", spec, opt);


### PR DESCRIPTION
Fixes #293.

This problem was introduced when I split the Vega stuff into Vega.jl.

@oheil, could you try this branch whether it fixes the error you reported?