### PR TITLE
Fix typical case for vlplot function

### DIFF
--- a/src/dsl_vlplot_function/dsl_vlplot_function.jl
+++ b/src/dsl_vlplot_function/dsl_vlplot_function.jl
@@ -4,7 +4,7 @@ struct VLFrag <: Vega.AbstractVegaFragment
 end
 
 function vlfrag(args...; kwargs...)
-    return VLFrag(Any[args...], OrderedDict{String,Any}(string(k)=>convert_nt_to_dict(v, VLFrag) for (k,v) in kwargs))
+    return VLFrag(Any[args...], OrderedDict{String,Any}(string(k)=>Vega.convert_nt_to_dict(v, VLFrag) for (k,v) in kwargs))
 end
 
 fix_shortcut_level_mark(spec_frag) = spec_frag


### PR DESCRIPTION
This fixes the case of 
```
using VegaLite, DataFrames
vlplot(data = DataFrame(x = 1:5, y = 1:5),
           mark = :point,
           x=:x,
           y=:y)
```
@davidanthoff could you check if the following case is working as expected?
```
vlplot(data = [(x = 1:5, y = 1:5)],
           mark = :point,
           x=:x,
           y=:y)
```