### PR TITLE
Replace fixed paths to artifacts with dynamic function calls

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -27,7 +27,7 @@ export @vg_str, @vgplot, vgplot, @vgfrag, vgfrag
 export load, save
 export deletedata, deletedata!
 
-function vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)
+vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)
 const vegaliate_app_includes_canvas = ispath(vegaliate_app_path("node_modules", "canvas"))
 
 const vlschema = JSON.parsefile(

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -28,11 +28,16 @@ export load, save
 export deletedata, deletedata!
 
 vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)
-const vegaliate_app_includes_canvas = ispath(vegaliate_app_path("node_modules", "canvas"))
+const vegaliate_app_includes_canvas = Ref{Bool}()
 
-const vlschema = JSON.parsefile(
-    vegaliate_app_path("schemas", "vega-lite-schema.json")
-)
+const vlschema = Ref{Dict{String, Any}}()
+
+function __init__()
+    vegaliate_app_includes_canvas[] = ispath(vegaliate_app_path("node_modules", "canvas"))
+    vlschema[] = JSON.parsefile(
+        vegaliate_app_path("schemas", "vega-lite-schema.json")
+    )
+end
 
 include("vlspec.jl")
 

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -27,7 +27,7 @@ export @vg_str, @vgplot, vgplot, @vgfrag, vgfrag
 export load, save
 export deletedata, deletedata!
 
-vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)
+vegalite_app_path(args...) = joinpath(artifact"vegalite_app", args...)
 const vegaliate_app_includes_canvas = Ref{Bool}()
 
 const vlschema = Ref{Dict{String, Any}}()

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -27,11 +27,11 @@ export @vg_str, @vgplot, vgplot, @vgfrag, vgfrag
 export load, save
 export deletedata, deletedata!
 
-const vegaliate_app_path = artifact"vegalite_app"
-const vegaliate_app_includes_canvas = ispath(joinpath(vegaliate_app_path, "node_modules", "canvas"))
+function vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)
+const vegaliate_app_includes_canvas = ispath(vegaliate_app_path("node_modules", "canvas"))
 
 const vlschema = JSON.parsefile(
-    joinpath(vegaliate_app_path, "schemas", "vega-lite-schema.json")
+    vegaliate_app_path("schemas", "vega-lite-schema.json")
 )
 
 include("vlspec.jl")

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -33,9 +33,9 @@ const vegaliate_app_includes_canvas = Ref{Bool}()
 const vlschema = Ref{Dict{String, Any}}()
 
 function __init__()
-    vegaliate_app_includes_canvas[] = ispath(vegaliate_app_path("node_modules", "canvas"))
+    vegaliate_app_includes_canvas[] = ispath(vegalite_app_path("node_modules", "canvas"))
     vlschema[] = JSON.parsefile(
-        vegaliate_app_path("schemas", "vega-lite-schema.json")
+        vegalite_app_path("schemas", "vega-lite-schema.json")
     )
 end
 

--- a/src/dsl_vlplot_function/dsl_vlplot_function.jl
+++ b/src/dsl_vlplot_function/dsl_vlplot_function.jl
@@ -118,7 +118,7 @@ function fix_shortcut_level_spec(spec_frag::VLFrag)
     # Move top level channels into encoding
     encodings_to_be_moved = filter(
         i -> i != "facet",
-        collect(keys(vlschema["definitions"]["FacetedEncoding"]["properties"])),
+        collect(keys(vlschema[]["definitions"]["FacetedEncoding"]["properties"])),
         )
     for k in collect(keys(spec))
         if string(k) in encodings_to_be_moved
@@ -222,7 +222,7 @@ function convert_frag_tree_to_dict(spec::VLFrag)
     spec_as_dict2 = Vega.walk_dict(spec_as_dict, "root") do p, parent
         if p[1] == "typ"
             Base.depwarn("`typ` in VegaLite.jl specs is deprecated, use `type` instead.", :vlplot)
-        
+
             return "type" => p[2]
         else
             return p

--- a/src/dsl_vlplot_function/shorthandparser.jl
+++ b/src/dsl_vlplot_function/shorthandparser.jl
@@ -37,7 +37,7 @@ function decode_typ(s::AbstractString)
         s = "temporal"
     end
     for key in ("StandardType", "TypeForShape")
-        if s in vlschema["definitions"][key]["enum"]
+        if s in vlschema[]["definitions"][key]["enum"]
             return "type" => s
         end
     end
@@ -46,7 +46,7 @@ end
 
 function decode_func(s::AbstractString)
     s = lowercase(s)
-    if s in vlschema["definitions"]["AggregateOp"]["enum"]
+    if s in vlschema[]["definitions"]["AggregateOp"]["enum"]
         return "aggregate" => s
     end
     for key in (
@@ -55,7 +55,7 @@ function decode_func(s::AbstractString)
         "UtcMultiTimeUnit",
         "UtcSingleTimeUnit",
     )
-        if s in vlschema["definitions"][key]["enum"]
+        if s in vlschema[]["definitions"][key]["enum"]
             return "timeUnit" => s
         end
     end

--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -4,7 +4,7 @@
 #
 ######################################################################
 
-asset(url...) = normpath(joinpath(vegaliate_app_path, "minified", url...))
+asset(url...) = normpath(vegaliate_app_path("minified", url...))
 
 # Vega Scaffold: https://github.com/vega/vega/wiki/Runtime
 

--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -5,10 +5,17 @@
 ######################################################################
 using JSON
 
-asset(url...) = normpath(vegaliate_app_path("minified", url...))
+asset(url...) = normpath(vegalite_app_path("minified", url...))
 
-package_json = JSON.parsefile(joinpath(vegaliate_app_path, "package.json"))
-version(package) = package_json["dependencies"][package]
+const package_json = Ref{Dict{String, Any}}()
+
+function version(package)
+  if !isassigned(package_json)
+    package_json[] = JSON.parsefile(vegalite_app_path("package.json"))
+  end
+  
+  return package_json[]["dependencies"][package]
+end
 
 # Vega Scaffold: https://github.com/vega/vega/wiki/Runtime
 

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -32,8 +32,8 @@ function convert_vl_to_x(v::VLSpec, second_script)
 end
 
 function convert_vl_to_svg(v::VLSpec)
-    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
-    vg2svg_script_path = vegaliate_app_path("vg2svg.js")
+    vl2vg_script_path = vegalite_app_path("vl2vg.js")
+    vg2svg_script_path = vegalite_app_path("vg2svg.js")
     p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegaliate_app_path())), "r+")
     writer = @async begin
         our_json_print(p, v)

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,6 +1,6 @@
 function convert_vl_to_vg(v::VLSpec)
-    vl2vg_script_path = joinpath(vegaliate_app_path, "vl2vg.js")
-    p = open(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path), "r+")
+    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
+    p = open(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -15,9 +15,9 @@ function convert_vl_to_vg(v::VLSpec)
 end
 
 function convert_vl_to_x(v::VLSpec, second_script)
-    vl2vg_script_path = joinpath(vegaliate_app_path, "vl2vg.js")
-    full_second_script_path = joinpath(vegaliate_app_path, "node_modules", "vega-cli", "bin", second_script)
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path), Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegaliate_app_path)), "r+")
+    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
+    full_second_script_path = vegaliate_app_path("node_modules", "vega-cli", "bin", second_script)
+    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegaliate_app_path())), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -32,9 +32,9 @@ function convert_vl_to_x(v::VLSpec, second_script)
 end
 
 function convert_vl_to_svg(v::VLSpec)
-    vl2vg_script_path = joinpath(vegaliate_app_path, "vl2vg.js")
-    vg2svg_script_path = joinpath(vegaliate_app_path, "vg2svg.js")
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegaliate_app_path)), "r+")
+    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
+    vg2svg_script_path = vegaliate_app_path("vg2svg.js")
+    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegaliate_app_path())), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,6 +1,6 @@
 function convert_vl_to_vg(v::VLSpec)
-    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
-    p = open(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), "r+")
+    vl2vg_script_path = vegalite_app_path("vl2vg.js")
+    p = open(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -15,9 +15,9 @@ function convert_vl_to_vg(v::VLSpec)
 end
 
 function convert_vl_to_x(v::VLSpec, second_script)
-    vl2vg_script_path = vegaliate_app_path("vl2vg.js")
-    full_second_script_path = vegaliate_app_path("node_modules", "vega-cli", "bin", second_script)
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegaliate_app_path())), "r+")
+    vl2vg_script_path = vegalite_app_path("vl2vg.js")
+    full_second_script_path = vegalite_app_path("node_modules", "vega-cli", "bin", second_script)
+    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegalite_app_path())), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -34,7 +34,7 @@ end
 function convert_vl_to_svg(v::VLSpec)
     vl2vg_script_path = vegalite_app_path("vl2vg.js")
     vg2svg_script_path = vegalite_app_path("vg2svg.js")
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegaliate_app_path()), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegaliate_app_path())), "r+")
+    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegalite_app_path())), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -64,7 +64,7 @@ function Base.show(io::IO, m::MIME"image/svg+xml", v::VLSpec)
 end
 
 function Base.show(io::IO, m::MIME"application/pdf", v::VLSpec)
-    if vegaliate_app_includes_canvas
+    if vegaliate_app_includes_canvas[]
         print(io, convert_vl_to_x(v, "vg2pdf"))
     else
         error("Not yet implemented.")
@@ -99,7 +99,7 @@ end
 # end
 
 function Base.show(io::IO, m::MIME"image/png", v::VLSpec)
-    if vegaliate_app_includes_canvas
+    if vegaliate_app_includes_canvas[]
         print(io, convert_vl_to_x(v, "vg2png"))
     else
         error("Not yet implemented.")


### PR DESCRIPTION
I tried to build a portable app from a package that relies on VegaLite using [PackageCompiler](https://github.com/JuliaLang/PackageCompiler.jl). It doesn't work in the current version, because [`vegaliate_app_path`](https://github.com/queryverse/VegaLite.jl/blob/master/src/VegaLite.jl#L30) stores predefined path to the artifacts. According to [the example](https://github.com/JuliaLang/PackageCompiler.jl/blob/master/examples/MyApp/src/MyApp.jl#L7), it should be done through function calls instead. So, in this PR, `vegaliate_app_path` is now a function: `vegaliate_app_path(args...) = joinpath(artifact"vegalite_app", args...)` with all calls updated. It fixes all issues on my tests.

Below is a way to reproduce failure of transferrability
1. Create a package that depends on VegaLite:

```julia
module VLBuild

using VegaLite

function julia_main()::Cint
    try
        save("./test.html", @vlplot(:point, x=1:3, y=1:3))
    catch err
        @error("$err\n\n" * join(["$s" for s in stacktrace(catch_backtrace())], "\n"))
        return 1
    end
    return 0
end

end
```

2. Build it with PackageCompiler

```julia
import VLBuild
using PackageCompiler
create_app(dirname(dirname(pathof(VLBuild))), "VLBuild"; force=true)
```

3. Transfer it to another OS with no julia installed. I used docker `ubuntu:latest`
4. Run the app `./VLBuild/bin/VLBuild`