### PR TITLE
Composition update proposal

### DIFF
--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -158,19 +158,13 @@ Base.:+(a::VLSpecTyped, b::MultiView) = b + a
 Base.:+(a::MultiView, b::VLSpecTyped) = error("Multi-view spec $(typeof(a)) can not be layered")
 Base.:+(a::MultiView, b::MultiView) = error("Multi-view spec $(typeof(a)) can not be layered")
 Base.:+(a::VLSpecTyped, b::VLSpecTyped) = error("Layering not implemented for $(typeof(a)) + $(typeof(b))")
-function Base.:+(a::SingleView, b::SingleView)
-    a_spec = deepcopy(Vega.getparams(a.spec))
-    b_spec = deepcopy(Vega.getparams(b.spec))
-    new_spec = OrderedDict{String,Any}()
-    new_spec["layer"] = [a_spec, b_spec]
-    return promote_data_to_toplevel(VLSpec(new_spec), "layer")
-end
 function Base.:+(a::Layer, b::Layer)
     a_spec = deepcopy(Vega.getparams(a.spec))
     b_spec = deepcopy(Vega.getparams(b.spec))
     append!(a_spec["layer"], b_spec["layer"])
     return promote_data_to_toplevel(VLSpec(a_spec), "layer")
 end
+Base.:+(a::SingleView, b::SingleView) = Layer(a) + Layer(b)
 Base.:+(a::SingleView, b::Layer) = Layer(a) + b
 Base.:+(a::Layer, b::SingleView) = a + Layer(b)
 

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -177,11 +177,28 @@ multiview_layering_error(a) = error("Multi-view spec $(typeof(a)) can not be lay
     spec1::VLSpec * spec2::VLSpec
 
 Multiplicating two `VLSpec` creates a new `VLSpec` as a composition of the two specifications.
+For instance, `vlplot(:bar) * vlplot(x=:x)` will be equivalent to `vlplot(:bar, x=:x)`.
 Properties defined in `spec2` have precedence over `spec1`, meaning that if a given property
 is specified in both then the result specification will use the property from `spec2`.
 
-# Examples
-some examples
+# Example
+
+using VegaLite, VegaDatasets
+
+data = dataset("weather.csv") |> vlplot();
+rep = @vlplot(repeat={column=[:temp_max,:precipitation,:wind]});
+common = @vlplot(
+    :line,
+    y={field={repeat=:column},aggregate=:mean,type=:quantitative},
+    x="month(date):o",
+    color=:location
+);
+details = @vlplot(
+    detail="year(date)",
+    opacity={value=0.2}
+);
+
+data * rep * common * (details + vlplot())
 """
 Base.:*(a::VLSpec, b::VLSpec) = Base.:*(VLSpecTyped(a), VLSpecTyped(b))
 Base.:*(a::MultiView, b::MultiView) = error("Two multi-view specs (facet, repeat, concat) can not be composed. Tried to compose ($(typeof(a)), $(typeof(b)))")


### PR DESCRIPTION
# Motivation

I'm a big fan of Vega-Lite and python's altair, and I'm very happy that this great julia version exists. I find VegaLite.jl very powerful, however I was initially very confused by the `+` operator. Unfortunately there are no documentation for its usage, other than few examples. After inspecting the code things get more clear, however I still find it not very intuitive and somewhat cumbersome. Then I learnt on several issues ([this one in particular](https://github.com/queryverse/VegaLite.jl/issues/230)) that the whole composition story is not fully finished and that's why there is no proper documentation.

# Solution proposal

This PR proposes the following solution:
- The operator `+` is updated to be used exclusively for layering.
- The operator `*` is introduced as a sort of modular composition. This allows to define separately sub components of a plot and put them together via the operator.

The sub spec operator proposed in #230 can naturally be done via the `*` operator. This doesn't adjust to the operator precedence discussion in the issue, however in my opinion it is totally natural the need to add the parenthesis in things like: 
```julia
@vlplot(repeat=...) * (layer1 + layer2)
```

with this proposal, one could do things like:
```julia
data = vlplot(data=...);
facet = vlplot(facet=...)
common_encoding = vlplot(enc=...);
p1 = vlplot(:point, shape=...)
p2 = vlplot(:line, color=...)

data * facet * common_encoding * (p1 + p2)
```

In my opinion this is a natural way of composing plots. Only after implementing this proposal I also noticed that it's also similar to how the fantastic AlgebraOfGraphics.jl works. 

# Next steps?

If you like this proposal, I'd be happy to include some tests and update the existing examples. Also, this is a prototype and I'm convinced that there are many ways the composition logic can be improved, happy to hear ideas.