### PR TITLE
Reduced time it takes to save VL to non-SVG outputs

### DIFF
--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -1,51 +1,51 @@
-function convert_vl_to_vg(v::VLSpec)
-    vl2vg_script_path = vegalite_app_path("vl2vg.js")
-    p = open(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), "r+")
-    writer = @async begin
-        our_json_print(p, v)
-        close(p.in)
-    end
+function _convert_vl_with_cmds(v::VLSpec, cmds...)
+    in_buf = IOBuffer()
+    our_json_print(in_buf, v)
+    seekstart(in_buf)
+
+    p = open(pipeline(in_buf, cmds...))
     reader = @async read(p, String)
     wait(p)
-    res = fetch(reader)
-    if p.exitcode != 0
+
+    if any(proc -> proc.exitcode != 0, p.processes)
+        # Is "Invalid spec" the only possible cause of failure?
         throw(ArgumentError("Invalid spec"))
     end
+
+    res = fetch(reader)
+
     return res
+end
+
+function convert_vl_to_vg(v::VLSpec)
+    vl2vg_script_path = vegalite_app_path("vl2vg.js")
+    return _convert_vl_with_cmds(
+        v,
+        Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()),
+    )
 end
 
 function convert_vl_to_x(v::VLSpec, second_script)
     vl2vg_script_path = vegalite_app_path("vl2vg.js")
     full_second_script_path = vegalite_app_path("node_modules", "vega-cli", "bin", second_script)
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegalite_app_path())), "r+")
-    writer = @async begin
-        our_json_print(p, v)
-        close(p.in)
-    end
-    reader = @async read(p, String)
-    wait(p)
-    res = fetch(reader)
-    if p.processes[1].exitcode != 0 || p.processes[2].exitcode != 0
-        throw(ArgumentError("Invalid spec"))
-    end
-    return res
+    
+    return _convert_vl_with_cmds(
+        v,
+        Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()),
+        Cmd(`$(nodejs_cmd()) $full_second_script_path -l error`, dir=vegalite_app_path()),
+    )
+
 end
 
 function convert_vl_to_svg(v::VLSpec)
     vl2vg_script_path = vegalite_app_path("vl2vg.js")
     vg2svg_script_path = vegalite_app_path("vg2svg.js")
-    p = open(pipeline(Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()), Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegalite_app_path())), "r+")
-    writer = @async begin
-        our_json_print(p, v)
-        close(p.in)
-    end
-    reader = @async read(p, String)
-    wait(p)
-    res = fetch(reader)
-    if p.processes[1].exitcode != 0 || p.processes[2].exitcode != 0
-        throw(ArgumentError("Invalid spec"))
-    end
-    return res
+
+    return _convert_vl_with_cmds(
+        v,
+        Cmd(`$(nodejs_cmd()) $vl2vg_script_path`, dir=vegalite_app_path()),
+        Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegalite_app_path()),
+    )
 end
 
 Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.vegalite.v4+json")}) = true

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -7,7 +7,7 @@ function _convert_vl_with_cmds(v::VLSpec, cmds...)
     reader = @async read(p, String)
     wait(p)
 
-    if any(proc -> proc.exitcode != 0, p.processes)
+    if (hasproperty(p, :exitcode) && p.exitcode != 0) || any(proc -> proc.exitcode != 0, p.processes)
         # Is "Invalid spec" the only possible cause of failure?
         throw(ArgumentError("Invalid spec"))
     end


### PR DESCRIPTION
Finally fixed the git snafus 😄. This commit has exactly the diff that fixes the long save times, as demonstrated below using the problematic code from #331.

# Before

```julia
(@v1.7) pkg> status VegaLite
      Status `~/.julia/environments/v1.7/Project.toml`
  [112f6efa] VegaLite v2.6.0

julia> using VegaLite

julia> x = 1:40000; y = sin.(x/1000);

julia> v = @vlplot(:line, x = x, y = y)

julia> @time save("test_vegalite.png", v)
┌ Warning: Mapping to the storage type failed; perhaps your data had out-of-range values?
│ Try `map(clamp01nan, img)` to clamp values to a valid range.
└ @ ImageMagick ~/.julia/packages/ImageMagick/b8swT/src/ImageMagick.jl:180
 58.086279 seconds (9.97 M allocations: 461.655 MiB, 0.91% gc time, 2.42% compilation time)

julia> @time save("test_vegalite.pdf", v)
┌ Warning: Mapping to the storage type failed; perhaps your data had out-of-range values?
│ Try `map(clamp01nan, img)` to clamp values to a valid range.
└ @ ImageMagick ~/.julia/packages/ImageMagick/b8swT/src/ImageMagick.jl:180
 55.264930 seconds (4.63 M allocations: 129.824 MiB, 0.06% gc time, 0.06% compilation time)
```

# After

```Julia
(@v1.7) pkg> status VegaLite
      Status `~/.julia/environments/v1.7/Project.toml`
  [112f6efa] VegaLite v2.6.1-DEV `~/Downloads/VegaLite.jl`

julia> using VegaLite

julia> x = 1:40000; y = sin.(x/1000);

julia> v = @vlplot(:line, x = x, y = y)

julia> @time save("test_vegalite.png", v)
┌ Warning: Mapping to the storage type failed; perhaps your data had out-of-range values?
│ Try `map(clamp01nan, img)` to clamp values to a valid range.
└ @ ImageMagick ~/.julia/packages/ImageMagick/b8swT/src/ImageMagick.jl:180
  1.006354 seconds (281.25 k allocations: 25.764 MiB, 3.82% gc time)

julia> @time save("test_vegalite.pdf", v)
┌ Warning: Mapping to the storage type failed; perhaps your data had out-of-range values?
│ Try `map(clamp01nan, img)` to clamp values to a valid range.
└ @ ImageMagick ~/.julia/packages/ImageMagick/b8swT/src/ImageMagick.jl:180
  1.027480 seconds (280.87 k allocations: 26.173 MiB)
```

(Not sure what's going on with those ImageMagick warnings, but that's for another investigation.)