### PR TITLE
Allow square bracket and dot notation in field names

### DIFF
--- a/src/dsl_vlplot_function/shorthandparser.jl
+++ b/src/dsl_vlplot_function/shorthandparser.jl
@@ -9,7 +9,7 @@ function tokenize_shorthand(s::AbstractString)
             end
             push!(tokens, s[i:i])
             curr_start = nextind(s, i)
-        elseif !(isletter(s[i]) || isnumeric(s[i]) || s[i] in ('_'))
+        elseif !(isletter(s[i]) || isnumeric(s[i]) || s[i] in ('_', '[', ']', '.'))
             throw(ArgumentError("Invalid shortcut string"))
         end
 


### PR DESCRIPTION
Fixes #285

allow square brackets, and dot (.) in shorthand field names for correct parsing by including the brackets and dot in allowed chars in else if statement.